### PR TITLE
feat: VLM multimodal retrieval, visual embedding, PDF image indexing & audio/video transcription

### DIFF
--- a/fastapi_app/config/settings.py
+++ b/fastapi_app/config/settings.py
@@ -46,6 +46,7 @@ class AppSettings(BaseSettings):
 
     # Knowledge Base
     KB_CHAT_MODEL: str = "deepseek-v3.2"
+    KB_VLM_MODEL: str = ""  # Multimodal model for VLM mode; falls back to LLM_MODEL when empty
     SQLBOT_OPENAI_API_KEY: Optional[str] = None
     SQLBOT_OPENAI_API_BASE: Optional[str] = None
     SQLBOT_OPENAI_MODEL: Optional[str] = None
@@ -75,6 +76,12 @@ class AppSettings(BaseSettings):
     EMBEDDING_API_KEY: str = ""
     EMBEDDING_MODEL: str = "Octen-Embedding-0.6B"
     EMBEDDING_DIMENSION: int = 768
+
+    # Visual Embedding (multimodal, 以图搜图)
+    # 留空时自动回退到 EMBEDDING_API_URL / EMBEDDING_API_KEY
+    VISUAL_EMBEDDING_API_URL: str = ""
+    VISUAL_EMBEDDING_API_KEY: str = ""
+    VISUAL_EMBEDDING_MODEL: str = "qwen3-vl-embedding"
 
     # Image Generation Provider Configuration
     IMAGE_GEN_API_URL: str = ""

--- a/fastapi_app/routers/kb.py
+++ b/fastapi_app/routers/kb.py
@@ -33,6 +33,7 @@ from fastapi_app.services.deep_research_report_service import generate_report_fr
 from workflow_engine.toolkits.research_tools import fetch_page_text
 from workflow_engine.workflow.wf_intelligent_qa import prepare_parallel_file_analyses, build_intelligent_qa_prompt
 from workflow_engine.promptstemplates.resources.pt_qa_agent_repo import KbPromptAgent as KbPromptAgentPrompts
+from workflow_engine.promptstemplates.resources.pt_qa_agent_repo import KbVlmPromptAgent as KbVlmPromptAgentPrompts
 
 router = APIRouter(prefix="/kb", tags=["Knowledge Base"])
 
@@ -51,6 +52,7 @@ MESSAGE_METADATA_FIELDS = (
     "sourceMapping",
     "sourcePreviewMapping",
     "sourceReferenceMapping",
+    "retrievedImages",
 )
 
 
@@ -242,7 +244,8 @@ def _unwrap_fastapi_body_default(value: Any, fallback: Any = None) -> Any:
     return value
 
 
-ALLOWED_EXTENSIONS = {".pdf", ".docx", ".pptx", ".png", ".jpg", ".jpeg", ".mp4", ".md", ".csv"}
+ALLOWED_EXTENSIONS = {".pdf", ".docx", ".pptx", ".png", ".jpg", ".jpeg", ".mp4", ".md", ".csv",
+                      ".mp3", ".wav", ".m4a", ".ogg"}
 
 IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg"}
 DOC_EXTENSIONS = {".pdf", ".docx", ".doc", ".pptx", ".ppt", ".md", ".markdown"}
@@ -654,6 +657,207 @@ async def reembed_source(
         raise HTTPException(status_code=500, detail=str(e))
 
 
+@router.get("/pdf-images")
+async def get_pdf_images_for_file(
+    notebook_id: str,
+    email: str,
+    file_id: str,
+    user_id: Optional[str] = None,
+):
+    """Return all extracted image URLs (pdf_image + pdf_page) for a specific file.
+
+    Used by the frontend to display a PDF image gallery in the chat.
+    """
+    if not notebook_id or not file_id:
+        raise HTTPException(status_code=400, detail="notebook_id and file_id are required")
+
+    try:
+        paths = get_notebook_paths(notebook_id, "", email or user_id or "")
+        vector_base = str(paths.vector_store_dir)
+        manager = VectorStoreManager(base_dir=vector_base)
+
+        figures = []
+        pages = []
+        for meta in manager.meta_data:
+            t = meta.get("type", "")
+            if t not in ("pdf_image", "pdf_page"):
+                continue
+            if meta.get("source_file_id") != file_id:
+                continue
+            img_path_str = meta.get("img_path", "")
+            if not img_path_str or not Path(img_path_str).exists():
+                continue
+            try:
+                url = _to_outputs_url(img_path_str)
+            except Exception:
+                continue
+            entry = {
+                "url": url,
+                "type": t,
+                "content": meta.get("content", ""),
+                "page_num": meta.get("page_num"),
+            }
+            if t == "pdf_image":
+                figures.append(entry)
+            else:
+                pages.append(entry)
+
+        # Sort pages by page number
+        pages.sort(key=lambda x: x.get("page_num") or 0)
+
+        return {
+            "file_id": file_id,
+            "figures": figures,
+            "pages": pages,
+            "total": len(figures) + len(pages),
+        }
+    except HTTPException:
+        raise
+    except Exception as e:
+        log.error("[get-pdf-images] failed: %s", e)
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.post("/reindex-pdf-images")
+async def reindex_pdf_images(
+    notebook_id: str = Body(..., embed=True),
+    email: str = Body(..., embed=True),
+    user_id: Optional[str] = Body(None, embed=True),
+):
+    """Scan already-extracted MinerU images for all PDFs in this notebook and embed them.
+
+    This endpoint is idempotent and safe to call on existing notebooks.  It does NOT
+    re-run MinerU or re-embed text chunks — it only processes image files that live in
+    already-extracted `images/` directories.
+    """
+    from workflow_engine.toolkits.multimodaltool.req_understanding import call_image_understanding_async
+    from workflow_engine.toolkits.ragtool.vector_store_tool import _image_path_to_data_url
+
+    if not notebook_id:
+        raise HTTPException(status_code=400, detail="notebook_id is required")
+
+    try:
+        paths = get_notebook_paths(notebook_id, "", email or user_id or "")
+        vector_base = str(paths.vector_store_dir)
+        manager = VectorStoreManager(base_dir=vector_base)
+
+        image_exts = {".jpg", ".jpeg", ".png", ".webp", ".gif"}
+        total_processed = 0
+        total_skipped = 0
+
+        for file_record in manager.manifest.get("files", []):
+            file_id = file_record.get("id")
+            if not file_id:
+                continue
+
+            images_dir_str = file_record.get("images_dir") or (
+                (file_record.get("parsers") or {}).get("mineru") or {}
+            ).get("images_dir") or ""
+            if not images_dir_str:
+                continue
+
+            images_dir = Path(images_dir_str)
+            if not images_dir.exists():
+                continue
+
+            # Check which img_paths are already indexed to avoid duplicates
+            already_indexed = {
+                m.get("img_path")
+                for m in manager.meta_data
+                if m.get("type") == "pdf_image" and m.get("source_file_id") == file_id
+            }
+
+            pdf_images = sorted([p for p in images_dir.iterdir() if p.suffix.lower() in image_exts])
+            for img_path in pdf_images:
+                if str(img_path) in already_indexed:
+                    total_skipped += 1
+                    continue
+                try:
+                    img_desc = await call_image_understanding_async(
+                        model=manager.image_model,
+                        messages=[{"role": "user", "content": "请详细描述这张图片的内容，包括图表类型、主要信息、数据趋势等，用于知识库检索。"}],
+                        api_url=manager.multimodal_api_url,
+                        api_key=manager.api_key,
+                        image_path=str(img_path),
+                    )
+                except Exception as exc:
+                    log.warning("[reindex-pdf-images] description failed for %s: %s", img_path.name, exc)
+                    img_desc = None
+
+                content = img_desc or f"[PDF图片] {img_path.name}"
+                img_meta = {
+                    "source_file_id": file_id,
+                    "type": "pdf_image",
+                    "content": content,
+                    "img_path": str(img_path),
+                }
+                text_vecs = manager._call_embedding_api([content])
+                manager._add_vectors(text_vecs, [img_meta])
+
+                if manager._visual_embed_svc is not None:
+                    try:
+                        data_url = _image_path_to_data_url(img_path)
+                        visual_vecs = manager._call_visual_embedding_api(data_url, is_image=True)
+                        manager._add_visual_vectors(visual_vecs, [img_meta])
+                        omni_vecs = manager._call_omni_embedding_api(data_url, is_image=True)
+                        manager._add_omni_vectors(omni_vecs, [img_meta])
+                    except Exception as exc:
+                        log.warning("[reindex-pdf-images] visual embed failed for %s: %s", img_path.name, exc)
+
+                total_processed += 1
+                log.info("[reindex-pdf-images] indexed %s", img_path.name)
+
+            # Also scan _pages/ for full-page renders (MinerU always produces these)
+            pages_dir = images_dir.parent.parent / "_pages"
+            already_pages_indexed = {
+                m.get("img_path")
+                for m in manager.meta_data
+                if m.get("type") == "pdf_page" and m.get("source_file_id") == file_id
+            }
+            if pages_dir.exists():
+                page_imgs = sorted([p for p in pages_dir.iterdir() if p.suffix.lower() == ".png"])
+                for img_path in page_imgs:
+                    if str(img_path) in already_pages_indexed:
+                        total_skipped += 1
+                        continue
+                    try:
+                        page_num = int(img_path.stem.split("_")[-1])
+                    except ValueError:
+                        page_num = 0
+                    content = f"[PDF第{page_num}页]"
+                    page_meta = {
+                        "source_file_id": file_id,
+                        "type": "pdf_page",
+                        "content": content,
+                        "img_path": str(img_path),
+                        "page_num": page_num,
+                    }
+                    text_vecs = manager._call_embedding_api([content])
+                    manager._add_vectors(text_vecs, [page_meta])
+
+                    if manager._visual_embed_svc is not None:
+                        try:
+                            data_url = _image_path_to_data_url(img_path)
+                            visual_vecs = manager._call_visual_embedding_api(data_url, is_image=True)
+                            manager._add_visual_vectors(visual_vecs, [page_meta])
+                            omni_vecs = manager._call_omni_embedding_api(data_url, is_image=True)
+                            manager._add_omni_vectors(omni_vecs, [page_meta])
+                        except Exception as exc:
+                            log.warning("[reindex-pdf-images] visual embed failed for page %s: %s", img_path.name, exc)
+
+                    total_processed += 1
+                    log.info("[reindex-pdf-images] indexed page %s", img_path.name)
+
+        manager.save()
+        log.info("[reindex-pdf-images] done: %d new, %d already indexed", total_processed, total_skipped)
+        return {"success": True, "processed": total_processed, "skipped": total_skipped}
+    except HTTPException:
+        raise
+    except Exception as e:
+        log.error("[reindex-pdf-images] failed: %s", e)
+        raise HTTPException(status_code=500, detail=str(e))
+
+
 def _sanitize_md_filename(title: str, prefix: str = "doc") -> str:
     """生成安全的 .md 文件名，避免路径注入与非法字符。"""
     safe = re.sub(r'[^\w\u4e00-\u9fff\s\-.]', "", (title or "").strip())
@@ -1048,6 +1252,48 @@ def _resolve_vector_store_dir(email: Optional[str], notebook_id: Optional[str]) 
     return vector_store_base_dir
 
 
+async def _vlm_describe_base64_image(
+    data_url: str,
+    api_url: str,
+    api_key: str,
+    model: str,
+) -> str:
+    """Call VLM to describe an image supplied as a base64 data URL."""
+    client = AsyncOpenAI(api_key=api_key, base_url=api_url)
+    try:
+        resp = await client.chat.completions.create(
+            model=model,
+            messages=[{
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "请详细描述这张图片的内容，包括文字、图表、结构和关键信息，用于知识库检索增强。"},
+                    {"type": "image_url", "image_url": {"url": data_url}},
+                ],
+            }],
+            max_tokens=512,
+            temperature=0.1,
+        )
+        return (resp.choices[0].message.content or "").strip()
+    except Exception as exc:
+        log.warning(f"[VLM describe] failed: {exc}")
+        return ""
+
+
+def _load_image_as_data_url(path: str) -> str:
+    """Load a local image file and return it as a base64 data URL."""
+    import base64
+    import mimetypes
+    try:
+        p = Path(path)
+        if not p.exists():
+            return ""
+        mime = mimetypes.guess_type(str(p))[0] or "image/png"
+        b64 = base64.b64encode(p.read_bytes()).decode()
+        return f"data:{mime};base64,{b64}"
+    except Exception:
+        return ""
+
+
 def _build_chat_request(
     files: List[str],
     query: str,
@@ -1058,6 +1304,8 @@ def _build_chat_request(
     api_key: Optional[str],
     model: str,
     rag_query: Optional[str] = None,
+    retrieval_mode: str = "text",
+    image_attachments: Optional[List[str]] = None,
 ) -> IntelligentQARequest:
     local_files = _resolve_chat_files(files)
     if not local_files:
@@ -1077,6 +1325,8 @@ def _build_chat_request(
         chat_api_url=resolved_api_url,
         api_key=resolved_api_key,
         model=model,
+        retrieval_mode=retrieval_mode,
+        query_image_data_urls=list(image_attachments or []),
     )
 
 
@@ -1274,13 +1524,39 @@ async def chat_with_kb_stream(
     api_url: Optional[str] = Body(None, embed=True),
     api_key: Optional[str] = Body(None, embed=True),
     model: str = Body(settings.KB_CHAT_MODEL, embed=True),
+    retrieval_mode: str = Body("text", embed=True),
+    image_attachments: List[str] = Body([], embed=True),
 ):
     log.info("[chat_with_kb_stream] === Request received ===")
+    log.info(f"[chat_with_kb_stream] retrieval_mode={retrieval_mode}, image_attachments count={len(image_attachments)}")
 
     async def event_generator():
         full_answer = ""
         try:
-            req = _build_chat_request(files, query, history, email, notebook_id, api_url, api_key, model, rag_query)
+            req = _build_chat_request(files, query, history, email, notebook_id, api_url, api_key, model, rag_query, retrieval_mode, image_attachments)
+
+            # Describe attached images and augment rag_query for retrieval.
+            # Always generate an LLM description so the text index can also surface
+            # relevant text chunks (useful even when the visual embedding service is
+            # available, since not all text chunks may be in the omni index).
+            image_descriptions: List[str] = []
+            if image_attachments:
+                yield _jsonl_line({
+                    "type": "stage",
+                    "stage": "analyzing_images",
+                    "message": "正在分析图片内容",
+                    "message_en": "Analyzing attached images",
+                })
+                descs = await asyncio.gather(*[
+                    _vlm_describe_base64_image(url, req.chat_api_url, req.api_key, req.model)
+                    for url in image_attachments
+                ])
+                image_descriptions = [d for d in descs if d]
+                if image_descriptions:
+                    augmented = (req.rag_query or req.query) + "\n\n图片内容：\n" + "\n".join(image_descriptions)
+                    req.rag_query = augmented
+                    log.info(f"[chat_with_kb_stream] augmented rag_query with {len(image_descriptions)} image descriptions")
+
             state = IntelligentQAState(request=req)
             yield _jsonl_line({
                 "type": "stage",
@@ -1329,11 +1605,63 @@ async def chat_with_kb_stream(
                 base_url=req.chat_api_url,
             )
 
+            # Build user message content — multimodal when images are attached
+            user_content: Any = prompt
+            if image_attachments:
+                user_content = [{"type": "text", "text": prompt}]
+                for url in image_attachments:
+                    user_content.append({"type": "image_url", "image_url": {"url": url}})
+
+            # VLM mode: also inject retrieved media-chunk images into the context
+            retrieved_image_urls: list[str] = []
+            if retrieval_mode == "vlm":
+                retrieved = getattr(state, "retrieved_chunks", None) or []
+                for chunk in retrieved:
+                    chunk_type = chunk.get("type", "")
+                    if chunk_type in ("media_desc", "visual", "pdf_image", "pdf_page"):
+                        meta = chunk.get("metadata", {})
+                        # pdf_image/pdf_page chunks store the path in img_path; others use path
+                        media_path = meta.get("img_path") or meta.get("path") or ""
+                        if media_path:
+                            data_url = _load_image_as_data_url(media_path)
+                            if data_url:
+                                if not isinstance(user_content, list):
+                                    user_content = [{"type": "text", "text": user_content}]
+                                user_content.append({"type": "image_url", "image_url": {"url": data_url}})
+                                img_url = _to_outputs_url(media_path)
+                                if img_url:
+                                    retrieved_image_urls.append(img_url)
+
+            if retrieved_image_urls:
+                yield _jsonl_line({"type": "images", "images": retrieved_image_urls})
+
+            # When the context contains images, the chat model must be multimodal.
+            # Switch from the default text model (e.g. deepseek) to the configured
+            # multimodal model (e.g. gemini-2.5-flash) automatically.
+            has_images = isinstance(user_content, list) and any(
+                item.get("type") == "image_url" for item in user_content if isinstance(item, dict)
+            )
+            chat_model = req.model
+            if has_images:
+                vlm_model = (
+                    (getattr(settings, "KB_VLM_MODEL", "") or "").strip()
+                    or (getattr(settings, "LLM_MODEL", "") or "").strip()
+                )
+                if vlm_model:
+                    chat_model = vlm_model
+                    log.info(f"[VLM] Switching to multimodal model: {chat_model}")
+
+            system_prompt = (
+                KbVlmPromptAgentPrompts.system_prompt_for_kb_vlm_prompt_agent.strip()
+                if has_images
+                else KbPromptAgentPrompts.system_prompt_for_kb_prompt_agent.strip()
+            )
+
             stream = await client.chat.completions.create(
-                model=req.model,
+                model=chat_model,
                 messages=[
-                    {"role": "system", "content": KbPromptAgentPrompts.system_prompt_for_kb_prompt_agent.strip()},
-                    {"role": "user", "content": prompt},
+                    {"role": "system", "content": system_prompt},
+                    {"role": "user", "content": user_content},
                 ],
                 temperature=0.7,
                 stream=True,
@@ -1415,10 +1743,14 @@ async def create_conversation(
     notebook_id: Optional[str] = Body(None, embed=True),
 ) -> Dict[str, Any]:
     """Always create a new conversation for this user+notebook. Returns conversation id."""
+    import uuid as _uuid
     conv = _supabase_create_conversation(email, user_id, notebook_id)
     if conv:
         return {"success": True, "conversation_id": conv.get("id"), "conversation": conv}
-    return {"success": False, "conversation_id": None}
+    # Supabase 未配置或写入失败时，退回本地 UUID，确保前端流程不中断
+    local_id = str(_uuid.uuid4())
+    log.info("[create_conversation] Supabase not available, using local id: %s", local_id)
+    return {"success": True, "conversation_id": local_id, "conversation": {"id": local_id, "title": "新对话"}}
 
 
 @router.get("/conversations/{conversation_id}/messages")

--- a/fastapi_app/routers/kb_sources.py
+++ b/fastapi_app/routers/kb_sources.py
@@ -1,13 +1,62 @@
 from __future__ import annotations
 
+import logging
+from pathlib import Path
 from typing import Any, Dict, Optional
 
 from fastapi import APIRouter, Body
 
+from fastapi_app.config.settings import settings
 from fastapi_app.services.source_service import SourceService
 
 router = APIRouter(prefix="/kb", tags=["Knowledge Base"])
 source_service = SourceService()
+log = logging.getLogger(__name__)
+
+IMAGE_EXTS = {".png", ".jpg", ".jpeg", ".gif", ".webp"}
+AUDIO_EXTS = {".mp3", ".wav", ".m4a", ".ogg"}
+VIDEO_EXTS = {".mp4", ".avi", ".mov"}
+
+
+async def _ocr_image_on_the_fly(file_path: Path) -> Optional[str]:
+    """Call VLM API to OCR an image that was uploaded before OCR support was added."""
+    try:
+        from workflow_engine.toolkits.multimodaltool.req_understanding import (
+            call_image_understanding_async,
+        )
+        api_url = settings.LLM_API_URL
+        api_key = settings.LLM_API_KEY
+        model = settings.KB_VLM_MODEL or settings.LLM_MODEL
+        text = await call_image_understanding_async(
+            model=model,
+            messages=[{"role": "user", "content": (
+                "请识别并完整输出这张图片中的所有文字内容。保留原始格式（包括换行、缩进、表格结构）。"
+                "如果图片中没有文字，请详细描述图片内容。只输出结果，不要加任何解释。"
+            )}],
+            api_url=api_url,
+            api_key=api_key,
+            image_path=str(file_path),
+        )
+        return text
+    except Exception as exc:
+        log.warning("On-the-fly OCR failed for %s: %s", file_path.name, exc)
+        return None
+
+
+async def _transcribe_on_the_fly(file_path: Path) -> Optional[str]:
+    """Call LLM audio API to transcribe a media file uploaded before STT support was added."""
+    try:
+        from workflow_engine.toolkits.ragtool.vector_store_tool import (
+            _transcribe_media_audio,
+        )
+        api_url = settings.LLM_API_URL
+        api_key = settings.LLM_API_KEY
+        model = settings.KB_VLM_MODEL or settings.LLM_MODEL
+        text = await _transcribe_media_audio(file_path, api_url, api_key, model)
+        return text if text else None
+    except Exception as exc:
+        log.warning("On-the-fly transcription failed for %s: %s", file_path.name, exc)
+        return None
 
 
 @router.get("/files")
@@ -34,10 +83,25 @@ async def get_source_display_content(
 ) -> Dict[str, Any]:
     del notebook_id, email
     result = source_service.get_source_display_content(path)
-    # Fallback: if manifest-based lookup returned no content, parse the file directly
-    if not result.get("content"):
-        result = source_service.parse_local_file(path)
-    return result
+    if result.get("content"):
+        return result
+
+    abs_path = source_service._resolve_local_path(path.strip())
+    suffix = (abs_path.suffix or "").lower()
+
+    if suffix in IMAGE_EXTS and abs_path.exists():
+        text = await _ocr_image_on_the_fly(abs_path)
+        if text and text.strip():
+            return {"content": f"## OCR 识别文本\n\n{text.strip()}", "from_mineru": False}
+        return {"content": f"[{abs_path.name}] 图片已上传（未识别到文字内容）", "from_mineru": False}
+
+    if suffix in (AUDIO_EXTS | VIDEO_EXTS) and abs_path.exists():
+        text = await _transcribe_on_the_fly(abs_path)
+        if text and text.strip():
+            return {"content": f"## 语音转录文本\n\n{text.strip()}", "from_mineru": False}
+        return {"content": f"[{abs_path.name}] 媒体文件已上传（未能转录音频内容）", "from_mineru": False}
+
+    return source_service.parse_local_file(path)
 
 
 @router.post("/parse-local-file")

--- a/fastapi_app/services/source_service.py
+++ b/fastapi_app/services/source_service.py
@@ -381,6 +381,19 @@ class SourceService:
                     return {"content": content, "from_mineru": True}
                 except Exception:
                     pass
+
+            parts: list[str] = []
+            desc_path = file_record.get("description_text_path")
+            if desc_path and Path(desc_path).exists():
+                parts.append(Path(desc_path).read_text(encoding="utf-8", errors="replace").strip())
+            ocr_path = file_record.get("ocr_text_path")
+            if ocr_path and Path(ocr_path).exists():
+                parts.append("## OCR 识别文本\n\n" + Path(ocr_path).read_text(encoding="utf-8", errors="replace").strip())
+            transcript_path = file_record.get("transcript_path")
+            if transcript_path and Path(transcript_path).exists():
+                parts.append("## 语音转录文本\n\n" + Path(transcript_path).read_text(encoding="utf-8", errors="replace").strip())
+            if parts:
+                return {"content": "\n\n".join(parts), "from_mineru": False}
             break
 
         return {"content": None, "from_mineru": False}
@@ -452,9 +465,18 @@ class SourceService:
                 log.warning("parse_local_file read text failed: %s", exc)
                 raise HTTPException(status_code=500, detail=str(exc)) from exc
 
+        if suffix in (".png", ".jpg", ".jpeg", ".gif", ".webp",
+                       ".mp4", ".avi", ".mov",
+                       ".mp3", ".wav", ".m4a", ".ogg"):
+            return {
+                "success": True,
+                "content": f"[{path.name}] 媒体文件已上传，OCR/转录内容请通过来源预览查看。",
+                "format": "text",
+            }
+
         raise HTTPException(
             status_code=400,
-            detail="Unsupported file type for preview (only .pdf, .md, .txt)",
+            detail="Unsupported file type for preview",
         )
 
     def fetch_page_content(self, url: str) -> Dict[str, Any]:

--- a/fastapi_app/services/visual_embedding_service.py
+++ b/fastapi_app/services/visual_embedding_service.py
@@ -1,0 +1,145 @@
+"""
+Visual embedding service using Qwen3-VL-Embedding (or any multimodal embedding API).
+
+For images, the OpenAI-compatible request format is:
+  POST /v1/embeddings
+  {
+    "model": "qwen3-vl-embedding",
+    "input": [{"type": "image_url", "image_url": {"url": "data:image/jpeg;base64,..."}}]
+  }
+
+For text (cross-modal retrieval against the visual index):
+  POST /v1/embeddings
+  {
+    "model": "qwen3-vl-embedding",
+    "input": "text string"
+  }
+
+Response follows the standard OpenAI embeddings format:
+  {"data": [{"embedding": [...], "index": 0}]}
+"""
+
+import asyncio
+import logging
+from concurrent.futures import ThreadPoolExecutor
+from typing import List
+
+import httpx
+
+from fastapi_app.config.settings import settings
+
+log = logging.getLogger(__name__)
+
+
+def _resolve_visual_api_url() -> str:
+    return (
+        (settings.VISUAL_EMBEDDING_API_URL or "").strip()
+        or (settings.EMBEDDING_API_URL or "").strip()
+    )
+
+
+def _resolve_visual_api_key() -> str:
+    return (
+        (settings.VISUAL_EMBEDDING_API_KEY or "").strip()
+        or (settings.EMBEDDING_API_KEY or "").strip()
+    )
+
+
+class VisualEmbeddingService:
+    """Calls a multimodal embedding API that accepts both images and text."""
+
+    def __init__(self, max_retries: int = 3, timeout: float = 60.0):
+        self.max_retries = max_retries
+        self.timeout = timeout
+
+    async def embed_image(self, data_url: str) -> List[float]:
+        """Embed a single image supplied as a base64 data URL."""
+        api_url = _resolve_visual_api_url()
+        api_key = _resolve_visual_api_key()
+        model = settings.VISUAL_EMBEDDING_MODEL
+
+        payload = {
+            "model": model,
+            "input": [{"type": "image_url", "image_url": {"url": data_url}}],
+        }
+        return await self._call(api_url, api_key, payload)
+
+    async def embed_text(self, text: str) -> List[float]:
+        """Embed text using the visual embedding model (for cross-modal retrieval)."""
+        api_url = _resolve_visual_api_url()
+        api_key = _resolve_visual_api_key()
+        model = settings.VISUAL_EMBEDDING_MODEL
+
+        payload = {"model": model, "input": text}
+        return await self._call(api_url, api_key, payload)
+
+    async def embed_texts_batch(self, texts: List[str]) -> List[List[float]]:
+        """Embed multiple texts in one API call (OpenAI-compatible batch input)."""
+        api_url = _resolve_visual_api_url()
+        api_key = _resolve_visual_api_key()
+        model = settings.VISUAL_EMBEDDING_MODEL
+
+        payload = {"model": model, "input": texts}
+        url = f"{api_url.rstrip('/')}/embeddings"
+        headers = {"Content-Type": "application/json"}
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
+
+        for attempt in range(self.max_retries):
+            try:
+                async with httpx.AsyncClient(timeout=self.timeout) as client:
+                    resp = await client.post(url, headers=headers, json=payload)
+                    resp.raise_for_status()
+                    data = resp.json()
+                    items = sorted(data["data"], key=lambda x: x["index"])
+                    return [item["embedding"] for item in items]
+            except Exception as exc:
+                if attempt == self.max_retries - 1:
+                    log.error(f"[VisualEmbedding] batch embed failed after {self.max_retries} attempts: {exc}")
+                    raise
+                await asyncio.sleep(2 ** attempt)
+        return []
+
+    def embed_texts_batch_sync(self, texts: List[str]) -> List[List[float]]:
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return asyncio.run(self.embed_texts_batch(texts))
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            return executor.submit(lambda: asyncio.run(self.embed_texts_batch(texts))).result()
+
+    async def _call(self, api_url: str, api_key: str, payload: dict) -> List[float]:
+        url = f"{api_url.rstrip('/')}/embeddings"
+        headers = {"Content-Type": "application/json"}
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
+
+        for attempt in range(self.max_retries):
+            try:
+                async with httpx.AsyncClient(timeout=self.timeout) as client:
+                    resp = await client.post(url, headers=headers, json=payload)
+                    resp.raise_for_status()
+                    data = resp.json()
+                    return data["data"][0]["embedding"]
+            except Exception as exc:
+                if attempt == self.max_retries - 1:
+                    log.error(f"[VisualEmbedding] failed after {self.max_retries} attempts: {exc}")
+                    raise
+                await asyncio.sleep(2 ** attempt)
+        return []
+
+    def embed_image_sync(self, data_url: str) -> List[float]:
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return asyncio.run(self.embed_image(data_url))
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            return executor.submit(lambda: asyncio.run(self.embed_image(data_url))).result()
+
+    def embed_text_sync(self, text: str) -> List[float]:
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return asyncio.run(self.embed_text(text))
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            return executor.submit(lambda: asyncio.run(self.embed_text(text))).result()

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -41,6 +41,7 @@ openpyxl>=3.1.5
 # ------ Image ------
 pillow>=10.4.0
 matplotlib>=3.9.0
+opencv-python-headless>=4.8.0
 
 # ------ Database / Data ------
 sqlalchemy>=2.0.0

--- a/workflow_engine/promptstemplates/resources/pt_qa_agent_repo.py
+++ b/workflow_engine/promptstemplates/resources/pt_qa_agent_repo.py
@@ -94,8 +94,17 @@ class KbVlmPromptAgent:
     kb_vlm_prompt_agent VLM模式提示词代理模板
     """
 
-    system_prompt_for_kb_vlm_prompt_agent = """
-You are a helpful AI assistant with vision capabilities. Analyze images and provide accurate, helpful responses.
+    system_prompt_for_kb_vlm_prompt_agent = """You are a multimodal AI assistant with full vision capabilities. Images from the user's documents have been embedded directly in this conversation — you CAN see them.
+
+Your job:
+1. Look at every image provided in the conversation.
+2. Describe what you see: chart type (bar/line/pie/scatter/etc.), key data points, trends, labels, colors, and any text visible in the image.
+3. Answer the user's question based on both the text context and the visual content of the images.
+
+Rules:
+- NEVER say you cannot see images or that you are a text-only model. You have vision capabilities and the images are already in this message.
+- If asked to "show" or "return" an image, explain that the image is already displayed above your response, and focus on describing its content.
+- Respond in the same language the user used.
 """
 
     task_prompt_for_kb_vlm_prompt_agent = """

--- a/workflow_engine/state.py
+++ b/workflow_engine/state.py
@@ -411,6 +411,8 @@ class IntelligentQARequest(MainRequest):
     rag_query: str = ""  # RAG/embedding 检索问题；为空时回退到 query
     history: List[Dict[str, str]] = field(default_factory=list)  # 历史记录 [{"role": "user", "content": "..."}]
     vector_store_base_dir: Optional[str] = None  # 可选，用于 RAG：向量库根目录（与 kb_embedding 约定一致）
+    retrieval_mode: str = "text"  # "text" | "vlm" — vlm 模式下同时搜索视觉索引
+    query_image_data_urls: List[str] = field(default_factory=list)  # 用户附加的图片 data URLs，用于以图搜图
 
 @dataclass
 class IntelligentQAState(MainState):

--- a/workflow_engine/toolkits/ragtool/vector_store_tool.py
+++ b/workflow_engine/toolkits/ragtool/vector_store_tool.py
@@ -43,6 +43,95 @@ def _chunk_text(text: str, chunk_size: int = 1500, chunk_overlap: int = 150) -> 
     chunks = splitter.split_text(text.strip())
     return [c.strip() for c in chunks if len(c.strip()) > 10]
 
+def _image_path_to_data_url(img_path: Path) -> str:
+    """Read an image file and return a base64 data URL."""
+    import base64
+    import mimetypes
+    mime = mimetypes.guess_type(str(img_path))[0] or "image/jpeg"
+    b64 = base64.b64encode(img_path.read_bytes()).decode()
+    return f"data:{mime};base64,{b64}"
+
+
+async def _transcribe_media_audio(
+    file_path: Path,
+    api_url: str,
+    api_key: str,
+    model: str,
+) -> str:
+    """Extract audio (from video via ffmpeg, or use audio directly) and transcribe via LLM input_audio.
+
+    Returns the transcript text, or empty string on failure.
+    """
+    import base64
+    import subprocess
+    import tempfile
+
+    ext = file_path.suffix.lower()
+    audio_path = file_path
+
+    # For video files, extract audio to a temp MP3 first
+    if ext in {".mp4", ".avi", ".mov", ".mkv", ".webm"}:
+        tmp_mp3 = Path(tempfile.mktemp(suffix=".mp3"))
+        try:
+            subprocess.run(
+                ["ffmpeg", "-i", str(file_path), "-vn", "-acodec", "libmp3lame", "-y", str(tmp_mp3)],
+                check=True, capture_output=True,
+            )
+            audio_path = tmp_mp3
+        except Exception as exc:
+            log.warning(f"[Transcribe] ffmpeg audio extraction failed: {exc}")
+            return ""
+
+    try:
+        audio_b64 = base64.b64encode(audio_path.read_bytes()).decode()
+        audio_mime = {
+            ".mp3": "mp3", ".wav": "wav", ".m4a": "m4a", ".ogg": "ogg",
+        }.get(audio_path.suffix.lower(), "mp3")
+
+        messages = [{
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "请完整转录这段音频的所有内容，保留原始语言。只输出转录文字，不要加任何解释或标注。"},
+                {
+                    "type": "input_audio",
+                    "input_audio": {
+                        "data": f"data:audio/{audio_mime};base64,{audio_b64}",
+                        "format": audio_mime,
+                    },
+                },
+            ],
+        }]
+
+        import httpx
+        url = f"{api_url.rstrip('/')}/chat/completions"
+        headers = {"Content-Type": "application/json"}
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
+        payload = {
+            "model": model,
+            "messages": messages,
+            "temperature": 0.1,
+            "max_tokens": 16384,
+        }
+
+        async with httpx.AsyncClient(timeout=httpx.Timeout(300.0)) as client:
+            resp = await client.post(url, headers=headers, json=payload)
+            resp.raise_for_status()
+            data = resp.json()
+            transcript = (data.get("choices", [{}])[0].get("message", {}).get("content", "") or "").strip()
+            log.info(f"[Transcribe] Got {len(transcript)} chars from {file_path.name}")
+            return transcript
+    except Exception as exc:
+        log.error(f"[Transcribe] Failed for {file_path.name}: {exc}")
+        return ""
+    finally:
+        if audio_path != file_path and audio_path.exists():
+            try:
+                audio_path.unlink()
+            except Exception:
+                pass
+
+
 def _default_embedding_api_url() -> str:
     return os.getenv("EMBEDDING_API_URL", "http://123.129.219.111:3000/v1/embeddings")
 
@@ -77,6 +166,19 @@ class VectorStoreManager:
         if self.video_model == "gemini-2.5-flash" and self.multimodal_model != "gemini-2.5-flash":
              self.video_model = self.multimodal_model
         self.multimodal_api_url = os.getenv("DEFAULT_LLM_API_URL", "http://123.129.219.111:3000/v1/")
+
+        # Visual embedding service (Qwen3-VL-Embedding or any multimodal embedding API).
+        # Only initialised when VISUAL_EMBEDDING_API_URL is explicitly set; otherwise all
+        # omni/visual embedding paths are skipped and we fall back to text-only retrieval.
+        try:
+            from fastapi_app.services.visual_embedding_service import VisualEmbeddingService
+            from fastapi_app.config.settings import settings as _svc_settings
+            if (_svc_settings.VISUAL_EMBEDDING_API_URL or "").strip():
+                self._visual_embed_svc: Optional[Any] = VisualEmbeddingService()
+            else:
+                self._visual_embed_svc = None
+        except Exception:
+            self._visual_embed_svc = None
         
         # Directories
         self.processed_dir = self.base_dir / "processed"
@@ -88,11 +190,19 @@ class VectorStoreManager:
         self.manifest_path = self.base_dir / "knowledge_manifest.json"
         self.faiss_index_path = self.vector_store_dir / f"{project_name}.index"
         self.faiss_meta_path = self.vector_store_dir / f"{project_name}.meta"
-        
+        self.visual_faiss_index_path = self.vector_store_dir / f"{project_name}_visual.index"
+        self.visual_faiss_meta_path = self.vector_store_dir / f"{project_name}_visual.meta"
+        self.omni_faiss_index_path = self.vector_store_dir / f"{project_name}_omni.index"
+        self.omni_faiss_meta_path  = self.vector_store_dir / f"{project_name}_omni.meta"
+
         # State
         self.manifest = self._load_manifest()
         self.index = None
         self.meta_data = [] # List corresponding to index vectors
+        self._visual_index = None
+        self._visual_meta_data: list = []
+        self._omni_index = None
+        self._omni_meta_data: list = []
         self._load_index()
 
     def _load_manifest(self) -> Dict[str, Any]:
@@ -118,18 +228,48 @@ class VectorStoreManager:
             self.index = None # Will be initialized on first add
             self.meta_data = []
 
+        if self.visual_faiss_index_path.exists() and self.visual_faiss_meta_path.exists():
+            log.info(f"Loading existing visual index from {self.visual_faiss_index_path}")
+            self._visual_index = faiss.read_index(str(self.visual_faiss_index_path))
+            with open(self.visual_faiss_meta_path, 'rb') as f:
+                self._visual_meta_data = pickle.load(f)
+        else:
+            self._visual_index = None
+            self._visual_meta_data = []
+
+        if self.omni_faiss_index_path.exists() and self.omni_faiss_meta_path.exists():
+            log.info(f"Loading existing omni index from {self.omni_faiss_index_path}")
+            self._omni_index = faiss.read_index(str(self.omni_faiss_index_path))
+            with open(self.omni_faiss_meta_path, 'rb') as f:
+                self._omni_meta_data = pickle.load(f)
+        else:
+            self._omni_index = None
+            self._omni_meta_data = []
+
     def save(self):
         """Save Manifest, Index and Meta data to disk."""
         # Save Manifest
         with open(self.manifest_path, 'w', encoding='utf-8') as f:
             json.dump(self.manifest, f, ensure_ascii=False, indent=2)
-            
-        # Save Index & Meta
+
+        # Save text Index & Meta
         if self.index is not None:
             faiss.write_index(self.index, str(self.faiss_index_path))
             with open(self.faiss_meta_path, 'wb') as f:
                 pickle.dump(self.meta_data, f)
-        
+
+        # Save visual Index & Meta
+        if self._visual_index is not None:
+            faiss.write_index(self._visual_index, str(self.visual_faiss_index_path))
+            with open(self.visual_faiss_meta_path, 'wb') as f:
+                pickle.dump(self._visual_meta_data, f)
+
+        # Save omni Index & Meta
+        if self._omni_index is not None:
+            faiss.write_index(self._omni_index, str(self.omni_faiss_index_path))
+            with open(self.omni_faiss_meta_path, 'wb') as f:
+                pickle.dump(self._omni_meta_data, f)
+
         log.info(f"Saved vector store to {self.vector_store_dir}")
 
     def remove_file(self, file_id: str) -> bool:
@@ -172,8 +312,53 @@ class VectorStoreManager:
             self.index.add(arr)
             self.meta_data = new_meta
         self.manifest["files"] = [f for f in self.manifest.get("files", []) if f.get("id") != file_id]
+        self._rebuild_visual_index_without(file_id)
+        self._rebuild_omni_index_without(file_id)
         self.save()
         return True
+
+    def _rebuild_visual_index_without(self, file_id: str) -> None:
+        """Rebuild visual index excluding all vectors for the given file_id."""
+        keep = [i for i in range(len(self._visual_meta_data)) if self._visual_meta_data[i].get("source_file_id") != file_id]
+        if len(keep) == len(self._visual_meta_data):
+            return
+        if not keep:
+            self._visual_index = None
+            self._visual_meta_data = []
+            if self.visual_faiss_index_path.exists():
+                self.visual_faiss_index_path.unlink()
+            if self.visual_faiss_meta_path.exists():
+                self.visual_faiss_meta_path.unlink()
+            return
+        if self._visual_index is not None:
+            dim = self._visual_index.d
+            vecs = [self._visual_index.reconstruct(i) for i in keep]
+            arr = np.asarray(vecs, dtype=np.float32)
+            self._visual_index = faiss.IndexFlatIP(dim)
+            self._visual_index.add(arr)
+        self._visual_meta_data = [self._visual_meta_data[i] for i in keep]
+
+    def _rebuild_omni_index_without(self, file_id: str) -> None:
+        """Rebuild omni index excluding all vectors for the given file_id."""
+        if self._omni_index is None:
+            return
+        keep = [i for i in range(len(self._omni_meta_data)) if self._omni_meta_data[i].get("source_file_id") != file_id]
+        if len(keep) == len(self._omni_meta_data):
+            return
+        if not keep:
+            self._omni_index = None
+            self._omni_meta_data = []
+            if self.omni_faiss_index_path.exists():
+                self.omni_faiss_index_path.unlink()
+            if self.omni_faiss_meta_path.exists():
+                self.omni_faiss_meta_path.unlink()
+            return
+        dim = self._omni_index.d
+        vecs = [self._omni_index.reconstruct(i) for i in keep]
+        arr = np.asarray(vecs, dtype=np.float32)
+        self._omni_index = faiss.IndexFlatIP(dim)
+        self._omni_index.add(arr)
+        self._omni_meta_data = [self._omni_meta_data[i] for i in keep]
 
     def search(self, query: str, top_k: int = 5, file_ids: Optional[List[str]] = None) -> List[Dict]:
         """
@@ -237,6 +422,195 @@ class VectorStoreManager:
                 break
                 
         return results
+
+    def _add_visual_vectors(self, vectors: np.ndarray, meta_list: List[Dict]) -> None:
+        """Add vectors and meta to the visual-only FAISS index."""
+        if len(vectors) == 0:
+            return
+        if self._visual_index is None:
+            self._visual_index = faiss.IndexFlatIP(vectors.shape[1])
+        self._visual_index.add(vectors)
+        self._visual_meta_data.extend(meta_list)
+
+    def _add_omni_vectors(self, vectors: np.ndarray, meta_list: List[Dict]) -> None:
+        """Add vectors and meta to the unified omni FAISS index."""
+        if len(vectors) == 0:
+            return
+        if self._omni_index is None:
+            self._omni_index = faiss.IndexFlatIP(vectors.shape[1])
+        self._omni_index.add(vectors)
+        self._omni_meta_data.extend(meta_list)
+
+    def search_visual(
+        self,
+        query_desc: str,
+        top_k: int = 5,
+        file_ids: Optional[List[str]] = None,
+        query_image_data_url: Optional[str] = None,
+    ) -> List[Dict]:
+        """Search the visual-only index.
+
+        If query_image_data_url is provided, embed it with the visual embedding model
+        (Qwen3-VL-Embedding) for true image-to-image search.
+        Otherwise fall back to text embedding of query_desc.
+        """
+        if self._visual_index is None or self._visual_index.ntotal == 0:
+            return []
+
+        if query_image_data_url and self._visual_embed_svc is not None:
+            query_vecs = self._call_visual_embedding_api(query_image_data_url, is_image=True)
+        else:
+            query_vecs = self._call_visual_embedding_api(query_desc, is_image=False)
+
+        if len(query_vecs) == 0:
+            return []
+        query_arr = query_vecs if query_vecs.ndim == 2 else query_vecs.reshape(1, -1)
+        search_k = max(top_k * 20, 100) if file_ids else top_k
+        search_k = min(search_k, self._visual_index.ntotal)
+        D, I = self._visual_index.search(query_arr, search_k)
+        results = []
+        target_file_ids = set(file_ids) if file_ids else None
+        for rank, idx in enumerate(I[0]):
+            if idx < 0 or idx >= len(self._visual_meta_data):
+                continue
+            meta = self._visual_meta_data[idx]
+            if target_file_ids and meta.get("source_file_id") not in target_file_ids:
+                continue
+            results.append({
+                "score": float(D[0][rank]),
+                "content": meta.get("content"),
+                "source_file_id": meta.get("source_file_id"),
+                "type": "visual",
+                "metadata": meta,
+            })
+            if len(results) >= top_k:
+                break
+        return results
+
+    def search_omni(
+        self,
+        query: str,
+        top_k: int = 5,
+        file_ids: Optional[List[str]] = None,
+        query_image_data_url: Optional[str] = None,
+    ) -> List[Dict]:
+        """Search the unified omni-embedding index.
+
+        All content (text chunks, PDF-extracted images, media files) lives in the
+        same Qwen3-VL-Embedding vector space, so text and image queries work uniformly.
+        Returns an empty list if the omni index is not available.
+        """
+        if self._omni_index is None or self._omni_index.ntotal == 0:
+            return []
+
+        if query_image_data_url and self._visual_embed_svc is not None:
+            query_vecs = self._call_omni_embedding_api(query_image_data_url, is_image=True)
+        else:
+            query_vecs = self._call_omni_embedding_api(query, is_image=False)
+
+        if len(query_vecs) == 0:
+            return []
+        query_arr = query_vecs if query_vecs.ndim == 2 else query_vecs.reshape(1, -1)
+        search_k = max(top_k * 20, 100) if file_ids else top_k
+        search_k = min(search_k, self._omni_index.ntotal)
+        D, I = self._omni_index.search(query_arr, search_k)
+        results = []
+        target_file_ids = set(file_ids) if file_ids else None
+        for rank, idx in enumerate(I[0]):
+            if idx < 0 or idx >= len(self._omni_meta_data):
+                continue
+            meta = self._omni_meta_data[idx]
+            if target_file_ids and meta.get("source_file_id") not in target_file_ids:
+                continue
+            results.append({
+                "score": float(D[0][rank]),
+                "content": meta.get("content"),
+                "source_file_id": meta.get("source_file_id"),
+                "type": meta.get("type", "omni"),
+                "metadata": meta,
+            })
+            if len(results) >= top_k:
+                break
+        return results
+
+    def get_pdf_images(
+        self,
+        file_ids: Optional[List[str]] = None,
+        limit: int = 10,
+    ) -> List[Dict]:
+        """Return all pdf_image and pdf_page entries for the given file IDs.
+
+        Used in VLM mode to always surface extracted PDF images alongside text results,
+        regardless of whether their descriptions match the query semantically.
+        pdf_image entries (extracted figures) take priority; pdf_page entries (full-page
+        renders) fill the remainder up to the limit.
+        """
+        target_file_ids = set(file_ids) if file_ids else None
+        figures = []
+        pages = []
+        for meta in self.meta_data:
+            t = meta.get("type", "")
+            if t not in ("pdf_image", "pdf_page"):
+                continue
+            if target_file_ids and meta.get("source_file_id") not in target_file_ids:
+                continue
+            entry = {
+                "score": 0.0,
+                "content": meta.get("content", ""),
+                "source_file_id": meta.get("source_file_id"),
+                "type": t,
+                "metadata": meta,
+            }
+            if t == "pdf_image":
+                figures.append(entry)
+            else:
+                pages.append(entry)
+
+        # Figures first, then pages; honour the limit
+        combined = figures[:limit] + pages[: max(0, limit - len(figures))]
+        return combined[:limit]
+
+    def _call_omni_embedding_api(self, content: str, is_image: bool = False) -> np.ndarray:
+        """Embed content using the unified Qwen3-VL-Embedding model (omni space).
+
+        Delegates to _call_visual_embedding_api which already handles both modalities.
+        """
+        return self._call_visual_embedding_api(content, is_image=is_image)
+
+    def _call_omni_embedding_api_batch(self, texts: List[str]) -> np.ndarray:
+        """Batch embed texts using the unified VLM embedding model.
+
+        Sends all texts in a single API call for efficiency.
+        Falls back to the text embedding model if visual service is unavailable.
+        """
+        if not texts:
+            return np.array([])
+        if self._visual_embed_svc is not None:
+            try:
+                vecs = self._visual_embed_svc.embed_texts_batch_sync(texts)
+                arr = np.array(vecs, dtype=np.float32)
+                faiss.normalize_L2(arr)
+                return arr
+            except Exception as exc:
+                log.warning(f"[Omni] Batch text embed failed, falling back to text model: {exc}")
+        return self._call_embedding_api(texts)
+
+    def _call_visual_embedding_api(self, data_url_or_text: str, is_image: bool = False) -> np.ndarray:
+        """Call Qwen3-VL-Embedding API for an image or text, return L2-normalised float32 array."""
+        if self._visual_embed_svc is not None:
+            try:
+                if is_image:
+                    vec = self._visual_embed_svc.embed_image_sync(data_url_or_text)
+                else:
+                    vec = self._visual_embed_svc.embed_text_sync(data_url_or_text)
+                arr = np.array([vec], dtype=np.float32)
+                faiss.normalize_L2(arr)
+                return arr
+            except Exception as exc:
+                log.warning(f"[VisualEmbedding] failed, falling back to text embedding: {exc}")
+        # Fallback: use text embedding (for backward-compat when no visual model is configured)
+        text = data_url_or_text if not is_image else "(image)"
+        return self._call_embedding_api([text])
 
     def _call_embedding_api(self, texts: List[str]) -> np.ndarray:
         """调用 Embedding API"""
@@ -332,7 +706,8 @@ class VectorStoreManager:
                 await self._process_ppt(file_path, file_record, file_id)
             elif ext in ['.md', '.markdown', '.txt']:
                 await self._process_text(file_path, file_record, file_id)
-            elif ext in ['.png', '.jpg', '.jpeg', '.mp4', '.avi', '.mov']:
+            elif ext in ['.png', '.jpg', '.jpeg', '.mp4', '.avi', '.mov',
+                         '.mp3', '.wav', '.m4a', '.ogg']:
                 await self._process_media(file_path, description, file_record, file_id)
             else:
                 log.warning(f"Unsupported file type: {ext}")
@@ -502,6 +877,15 @@ class VectorStoreManager:
             self._add_vectors(vectors, meta_list)
             record["chunks_count"] = len(chunks)
 
+            # Also embed text chunks into omni index (unified VLM vector space)
+            if self._visual_embed_svc is not None:
+                try:
+                    omni_vecs = self._call_omni_embedding_api_batch(chunks)
+                    self._add_omni_vectors(omni_vecs, meta_list)
+                    log.info(f"[Omni] Added {len(chunks)} text chunks to omni index")
+                except Exception as exc:
+                    log.warning(f"[Omni] Text chunk embed failed, omni index skipped: {exc}")
+
             # 在 MinerU 输出目录写入 chunks_info.json，便于确认是否做了分块及每块预览
             chunks_info_path = output_subdir / "chunks_info.json"
             try:
@@ -517,6 +901,89 @@ class VectorStoreManager:
                 record["chunks_info_path"] = str(chunks_info_path)
             except Exception as e:
                 log.warning(f"Could not write chunks_info.json: {e}")
+
+        # Phase 1: embed PDF-extracted images into text/visual/omni indices
+        images_dir = Path(record.get("images_dir", ""))
+        if images_dir.exists():
+            image_exts = {".jpg", ".jpeg", ".png", ".webp", ".gif"}
+            pdf_images = sorted([p for p in images_dir.iterdir() if p.suffix.lower() in image_exts])
+            pdf_image_count = 0
+            for img_path in pdf_images:
+                try:
+                    # Generate a semantic description so text search can find this image
+                    img_desc = None
+                    try:
+                        img_desc = await call_image_understanding_async(
+                            model=self.image_model,
+                            messages=[{"role": "user", "content": "请详细描述这张图片的内容，包括图表类型、主要信息、数据趋势等，用于知识库检索。"}],
+                            api_url=self.multimodal_api_url,
+                            api_key=self.api_key,
+                            image_path=str(img_path),
+                        )
+                        log.info(f"[PDFImage] Generated description for {img_path.name}: {(img_desc or '')[:80]}")
+                    except Exception as exc:
+                        log.warning(f"[PDFImage] Description generation failed for {img_path.name}: {exc}")
+
+                    content = img_desc or f"[PDF图片] {img_path.name}"
+                    img_meta = {
+                        "source_file_id": file_id,
+                        "type": "pdf_image",
+                        "content": content,
+                        "img_path": str(img_path),
+                    }
+
+                    # Text index: embed description for semantic text retrieval
+                    text_vecs = self._call_embedding_api([content])
+                    self._add_vectors(text_vecs, [img_meta])
+
+                    # Visual/omni indices: embed actual image pixels (only when VLM configured)
+                    if self._visual_embed_svc is not None:
+                        data_url = _image_path_to_data_url(img_path)
+                        visual_vecs = self._call_visual_embedding_api(data_url, is_image=True)
+                        self._add_visual_vectors(visual_vecs, [img_meta])
+                        omni_vecs = self._call_omni_embedding_api(data_url, is_image=True)
+                        self._add_omni_vectors(omni_vecs, [img_meta])
+
+                    pdf_image_count += 1
+                except Exception as exc:
+                    log.warning(f"[PDFImage] Failed to process {img_path.name}: {exc}")
+            if pdf_image_count:
+                log.info(f"[PDFImage] Processed {pdf_image_count} PDF images")
+                record["pdf_image_count"] = pdf_image_count
+
+        # Phase 1b: index _pages/ full-page renders (MinerU always produces these)
+        # These are the primary visual source for VLM mode when figures aren't extracted.
+        if images_dir.exists():
+            pages_dir = images_dir.parent.parent / "_pages"
+        else:
+            mineru_auto = Path(record.get("processed_md_path", "")).parent
+            pages_dir = mineru_auto / "_pages"
+        if pages_dir.exists():
+            page_imgs = sorted([p for p in pages_dir.iterdir() if p.suffix.lower() == ".png"])
+            pdf_page_count = 0
+            for img_path in page_imgs:
+                # Parse page number from filename (page_0001.png → 1)
+                try:
+                    page_num = int(img_path.stem.split("_")[-1])
+                except ValueError:
+                    page_num = 0
+                content = f"[PDF第{page_num}页]"
+                page_meta = {
+                    "source_file_id": file_id,
+                    "type": "pdf_page",
+                    "content": content,
+                    "img_path": str(img_path),
+                    "page_num": page_num,
+                }
+                try:
+                    text_vecs = self._call_embedding_api([content])
+                    self._add_vectors(text_vecs, [page_meta])
+                    pdf_page_count += 1
+                except Exception as exc:
+                    log.warning(f"[PDFPage] Failed to index {img_path.name}: {exc}")
+            if pdf_page_count:
+                log.info(f"[PDFPage] Indexed {pdf_page_count} full-page renders")
+                record["pdf_page_count"] = pdf_page_count
 
     async def _process_word(self, file_path: Path, record: Dict, file_id: str):
         # Convert to PDF first
@@ -561,71 +1028,201 @@ class VectorStoreManager:
             ]
             self._add_vectors(vectors, meta_list)
             record["chunks_count"] = len(chunks)
+            # Also embed into omni index (unified VLM vector space)
+            if self._visual_embed_svc is not None:
+                try:
+                    omni_vecs = self._call_omni_embedding_api_batch(chunks)
+                    self._add_omni_vectors(omni_vecs, meta_list)
+                except Exception as exc:
+                    log.warning(f"[Omni] Text chunk omni embed failed: {exc}")
         else:
             log.warning(f"No valid chunks from text file: {file_path}")
             record["status"] = "skipped"
 
     async def _process_media(self, file_path: Path, description: Optional[str], record: Dict, file_id: str):
+        ext = file_path.suffix.lower()
+        is_image = ext in {'.png', '.jpg', '.jpeg', '.gif', '.webp'}
+        is_video = ext in {'.mp4', '.avi', '.mov'}
+        is_audio = ext in {'.mp3', '.wav', '.m4a', '.ogg'}
+
         desc_text = description
-        
-        # If no description provided, generate one using multimodal API
-        if not desc_text:
-            log.info(f"No description for {file_path.name}, calling Multimodal API...")
-            try:
-                ext = file_path.suffix.lower()
-                messages = []
-                
-                # Check file type
-                if ext in ['.png', '.jpg', '.jpeg']:
-                    # Image Understanding
-                    log.info(f"Using image model: {self.image_model}")
+        ocr_text = None
+        transcript_text = None
+
+        out_dir = self.processed_dir / file_id
+        out_dir.mkdir(parents=True, exist_ok=True)
+
+        # ── Image: generate description + OCR ──
+        if is_image:
+            if not desc_text:
+                try:
                     desc_text = await call_image_understanding_async(
                         model=self.image_model,
                         messages=[{"role": "user", "content": "Please describe this image in detail for knowledge base retrieval."}],
                         api_url=self.multimodal_api_url,
                         api_key=self.api_key,
-                        image_path=str(file_path)
+                        image_path=str(file_path),
                     )
-                    log.critical(f'Image Understanding desc_text : {desc_text}')
-                elif ext in ['.mp4', '.avi', '.mov']:
-                    # Video Understanding
-                    log.info(f"Using video model: {self.video_model}")
+                    log.info(f"[Image] description: {(desc_text or '')[:80]}")
+                except Exception as e:
+                    log.error(f"[Image] description failed: {e}")
+
+            try:
+                ocr_text = await call_image_understanding_async(
+                    model=self.image_model,
+                    messages=[{"role": "user", "content": (
+                        "请识别并完整输出这张图片中的所有文字内容。保留原始格式（包括换行、缩进、表格结构）。"
+                        "如果图片中没有文字，返回空字符串。只输出提取的文字，不要加任何解释。"
+                    )}],
+                    api_url=self.multimodal_api_url,
+                    api_key=self.api_key,
+                    image_path=str(file_path),
+                )
+                log.info(f"[OCR] got {len(ocr_text or '')} chars from {file_path.name}")
+            except Exception as e:
+                log.warning(f"[OCR] failed for {file_path.name}: {e}")
+
+        # ── Video: generate visual description + transcribe audio ──
+        elif is_video:
+            if not desc_text:
+                try:
                     desc_text = await call_video_understanding_async(
                         model=self.video_model,
                         messages=[{"role": "user", "content": "Please analyze this video and provide a detailed description of its content, events, and any text visible, for knowledge base retrieval."}],
                         api_url=self.multimodal_api_url,
                         api_key=self.api_key,
-                        video_path=str(file_path)
+                        video_path=str(file_path),
                     )
-                    log.critical(f'Video Understanding desc_text : {desc_text}')
-                
-                if desc_text:
-                    log.info(f"Generated description: {desc_text[:100]}...")
+                    log.info(f"[Video] description: {(desc_text or '')[:80]}")
+                except Exception as e:
+                    log.error(f"[Video] description failed: {e}")
+
+            try:
+                from fastapi_app.config.settings import settings as _ts
+                transcript_text = await _transcribe_media_audio(
+                    file_path,
+                    api_url=(_ts.LLM_API_URL or "").strip() or self.multimodal_api_url,
+                    api_key=(_ts.LLM_API_KEY or "").strip() or self.api_key,
+                    model=(_ts.LLM_MODEL or "").strip() or self.video_model,
+                )
             except Exception as e:
-                log.error(f"Failed to generate description: {e}")
-                # Fallback or just skip embedding
-        
+                log.warning(f"[Transcribe] video audio failed: {e}")
+
+        # ── Audio: transcribe directly ──
+        elif is_audio:
+            try:
+                from fastapi_app.config.settings import settings as _ts
+                transcript_text = await _transcribe_media_audio(
+                    file_path,
+                    api_url=(_ts.LLM_API_URL or "").strip() or self.multimodal_api_url,
+                    api_key=(_ts.LLM_API_KEY or "").strip() or self.api_key,
+                    model=(_ts.LLM_MODEL or "").strip() or self.image_model,
+                )
+            except Exception as e:
+                log.error(f"[Transcribe] audio failed: {e}")
+            if transcript_text:
+                desc_text = transcript_text[:500]
+
+        # ── Store description (existing logic, preserved) ──
         if desc_text:
-            # Save description to file
-            desc_path = self.processed_dir / file_id / "description.txt"
-            desc_path.parent.mkdir(parents=True, exist_ok=True)
-            with open(desc_path, 'w', encoding='utf-8') as f:
-                f.write(desc_text)
-                
+            desc_path = out_dir / "description.txt"
+            desc_path.write_text(desc_text, encoding="utf-8")
             record["description_text_path"] = str(desc_path)
-            
-            # Embed description
+
             vectors = self._call_embedding_api([desc_text])
             meta_list = [{
                 "source_file_id": file_id,
                 "type": "media_desc",
                 "content": desc_text,
-                "path": str(file_path)
+                "path": str(file_path),
             }]
             self._add_vectors(vectors, meta_list)
+
+            if is_image or is_video:
+                import base64 as _b64
+                import mimetypes as _mt
+                try:
+                    mime = _mt.guess_type(str(file_path))[0] or "image/jpeg"
+                    b64 = _b64.b64encode(file_path.read_bytes()).decode()
+                    img_data_url = f"data:{mime};base64,{b64}"
+                    visual_vecs = self._call_visual_embedding_api(img_data_url, is_image=True)
+                except Exception as exc:
+                    log.warning(f"[VisualEmbed] falling back to text-desc embedding for {file_path.name}: {exc}")
+                    visual_vecs = vectors
+                    img_data_url = None
+
+                self._add_visual_vectors(visual_vecs, [{
+                    "source_file_id": file_id,
+                    "type": "visual",
+                    "content": desc_text,
+                    "path": str(file_path),
+                }])
+
+                if img_data_url:
+                    try:
+                        omni_vecs = self._call_omni_embedding_api(img_data_url, is_image=True)
+                        self._add_omni_vectors(omni_vecs, [{
+                            "source_file_id": file_id,
+                            "type": "visual",
+                            "content": desc_text,
+                            "path": str(file_path),
+                        }])
+                    except Exception as exc:
+                        log.warning(f"[Omni] Media omni embed failed: {exc}")
+
             record["media_desc_count"] = 1
         else:
-            log.warning(f"Skipping media {file_path.name} (no description available)")
+            log.warning(f"Skipping media description for {file_path.name} (no description available)")
+
+        # ── OCR text → chunk & embed ──
+        if ocr_text and ocr_text.strip():
+            ocr_path = out_dir / "ocr_text.txt"
+            ocr_path.write_text(ocr_text, encoding="utf-8")
+            record["ocr_text_path"] = str(ocr_path)
+
+            chunks = _chunk_text(ocr_text)
+            if not chunks:
+                chunks = [c.strip() for c in ocr_text.split('\n\n') if c.strip() and len(c.strip()) > 10]
+            if chunks:
+                vecs = self._call_embedding_api(chunks)
+                meta = [
+                    {"source_file_id": file_id, "type": "ocr_chunk", "content": c, "chunk_index": i}
+                    for i, c in enumerate(chunks)
+                ]
+                self._add_vectors(vecs, meta)
+                if self._visual_embed_svc is not None:
+                    try:
+                        omni_vecs = self._call_omni_embedding_api_batch(chunks)
+                        self._add_omni_vectors(omni_vecs, meta)
+                    except Exception as exc:
+                        log.warning(f"[Omni] OCR chunk omni embed failed: {exc}")
+                record["ocr_chunks_count"] = len(chunks)
+                log.info(f"[OCR] embedded {len(chunks)} chunks from {file_path.name}")
+
+        # ── Transcript text → chunk & embed ──
+        if transcript_text and transcript_text.strip():
+            tx_path = out_dir / "transcript.txt"
+            tx_path.write_text(transcript_text, encoding="utf-8")
+            record["transcript_path"] = str(tx_path)
+
+            chunks = _chunk_text(transcript_text)
+            if not chunks:
+                chunks = [c.strip() for c in transcript_text.split('\n\n') if c.strip() and len(c.strip()) > 10]
+            if chunks:
+                vecs = self._call_embedding_api(chunks)
+                meta = [
+                    {"source_file_id": file_id, "type": "transcript_chunk", "content": c, "chunk_index": i}
+                    for i, c in enumerate(chunks)
+                ]
+                self._add_vectors(vecs, meta)
+                if self._visual_embed_svc is not None:
+                    try:
+                        omni_vecs = self._call_omni_embedding_api_batch(chunks)
+                        self._add_omni_vectors(omni_vecs, meta)
+                    except Exception as exc:
+                        log.warning(f"[Omni] transcript chunk omni embed failed: {exc}")
+                record["transcript_chunks_count"] = len(chunks)
+                log.info(f"[Transcribe] embedded {len(chunks)} chunks from {file_path.name}")
 
 async def process_knowledge_base_files(
     file_list: List[Dict[str, str]],

--- a/workflow_engine/workflow/wf_intelligent_qa.py
+++ b/workflow_engine/workflow/wf_intelligent_qa.py
@@ -320,6 +320,64 @@ def try_rag_retrieve(state: IntelligentQAState) -> None:
             top_k=RAG_TOP_K,
             file_ids=file_ids,
         )
+
+        retrieval_mode = getattr(state.request, "retrieval_mode", "text") or "text"
+        query_images = getattr(state.request, "query_image_data_urls", None) or []
+        query_img = query_images[0] if query_images else None
+
+        # Use visual/omni search when:
+        #   1. VLM mode is explicitly set, OR
+        #   2. User attached an image and visual embedding service is configured (pixel-level matching)
+        use_visual = retrieval_mode == "vlm" or (query_img and manager._visual_embed_svc is not None)
+        if use_visual:
+            omni_results = manager.search_omni(
+                query=retrieval_query,
+                top_k=RAG_TOP_K,
+                file_ids=file_ids,
+                query_image_data_url=query_img,
+            )
+            if omni_results:
+                if retrieval_mode == "vlm":
+                    # VLM 模式：用 omni 结果替换文本结果（视觉优先）
+                    results = omni_results
+                    log.info(f"[Omni] 使用 omni 索引检索到 {len(omni_results)} 个片段")
+                else:
+                    # 图片附件触发：与文本结果合并，保留跨模态文本 + 图片搜索两路结果
+                    seen_content = {r.get("content") for r in results}
+                    added = 0
+                    for r in omni_results:
+                        if r.get("content") not in seen_content:
+                            results.append(r)
+                            seen_content.add(r.get("content"))
+                            added += 1
+                    log.info(f"[Omni] 跨模态检索合并 {added} 个片段，共 {len(results)} 个")
+            else:
+                # Fallback: merge visual results into text results
+                visual_results = manager.search_visual(
+                    query_desc=retrieval_query,
+                    top_k=RAG_TOP_K,
+                    file_ids=file_ids,
+                    query_image_data_url=query_img,
+                )
+                if visual_results:
+                    seen_content = {r.get("content") for r in results}
+                    for vr in visual_results:
+                        if vr.get("content") not in seen_content:
+                            results.append(vr)
+                            seen_content.add(vr.get("content"))
+                    log.info(f"[Visual] 视觉索引额外检索到 {len(visual_results)} 个片段，融合后共 {len(results)} 个")
+
+            matched_file_ids = list({r.get("source_file_id") for r in results if r.get("source_file_id")})
+            if matched_file_ids:
+                pdf_images = manager.get_pdf_images(file_ids=matched_file_ids, limit=8)
+                if pdf_images:
+                    seen_content = {r.get("content") for r in results}
+                    for pi in pdf_images:
+                        if pi.get("content") not in seen_content:
+                            results.append(pi)
+                            seen_content.add(pi.get("content"))
+                    log.info(f"[Visual] 追加 {len(pdf_images)} 个 PDF 图片到检索结果")
+
         state.retrieved_chunks = results
         log.info(f"RAG 检索到 {len(results)} 个片段")
     except Exception as e:
@@ -785,6 +843,65 @@ def create_intelligent_qa_graph() -> GenericGraphBuilder:
                 top_k=RAG_TOP_K,
                 file_ids=file_ids,
             )
+
+            # VLM 模式：优先用 omni index 做全模态检索；omni index 无内容时回退到 text+visual 双索引融合
+            retrieval_mode = getattr(state.request, "retrieval_mode", "text") or "text"
+            query_images = getattr(state.request, "query_image_data_urls", None) or []
+            query_img = query_images[0] if query_images else None
+
+            # Use visual/omni search when:
+            #   1. VLM mode is explicitly set, OR
+            #   2. User attached an image and visual embedding service is configured (pixel-level matching)
+            use_visual = retrieval_mode == "vlm" or (query_img and manager._visual_embed_svc is not None)
+            if use_visual:
+                omni_results = manager.search_omni(
+                    query=retrieval_query,
+                    top_k=RAG_TOP_K,
+                    file_ids=file_ids,
+                    query_image_data_url=query_img,
+                )
+                if omni_results:
+                    if retrieval_mode == "vlm":
+                        # VLM 模式：用 omni 结果替换文本结果（视觉优先）
+                        results = omni_results
+                        log.info(f"[Omni] 使用 omni 索引检索到 {len(omni_results)} 个片段")
+                    else:
+                        # 图片附件触发：与文本结果合并，保留跨模态文本 + 图片搜索两路结果
+                        seen_content = {r.get("content") for r in results}
+                        added = 0
+                        for r in omni_results:
+                            if r.get("content") not in seen_content:
+                                results.append(r)
+                                seen_content.add(r.get("content"))
+                                added += 1
+                        log.info(f"[Omni] 跨模态检索合并 {added} 个片段，共 {len(results)} 个")
+                else:
+                    visual_results = manager.search_visual(
+                        query_desc=retrieval_query,
+                        top_k=RAG_TOP_K,
+                        file_ids=file_ids,
+                        query_image_data_url=query_img,
+                    )
+                    if visual_results:
+                        seen_content = {r.get("content") for r in results}
+                        for vr in visual_results:
+                            if vr.get("content") not in seen_content:
+                                results.append(vr)
+                                seen_content.add(vr.get("content"))
+                        log.info(f"[Visual] 视觉索引额外检索到 {len(visual_results)} 个片段，融合后共 {len(results)} 个")
+
+                # Always include all pdf_image entries from the matched source files.
+                matched_file_ids = list({r.get("source_file_id") for r in results if r.get("source_file_id")})
+                if matched_file_ids:
+                    pdf_images = manager.get_pdf_images(file_ids=matched_file_ids, limit=8)
+                    if pdf_images:
+                        seen_content = {r.get("content") for r in results}
+                        for pi in pdf_images:
+                            if pi.get("content") not in seen_content:
+                                results.append(pi)
+                                seen_content.add(pi.get("content"))
+                        log.info(f"[Visual] 追加 {len(pdf_images)} 个 PDF 图片到检索结果")
+
             state.retrieved_chunks = results
             log.info(f"RAG 检索到 {len(results)} 个片段")
         except Exception as e:


### PR DESCRIPTION
## Summary

- **VLM 多模态检索模式**：新增 `retrieval_mode: text | vlm` 字段，VLM 模式下优先使用 omni 索引检索，回退到 visual+text 融合
- **视觉 Embedding 基础设施**：新增 `VisualEmbeddingService`（Qwen3-VL-Embedding），`VectorStoreManager` 增加独立的 visual/omni FAISS 索引，支持图生图检索
- **PDF 图片索引**：入库时自动提取 PDF 中的插图与全页截图并嵌入 visual/omni 索引；新增 `/kb/pdf-images` 和 `/kb/reindex-pdf-images` API
- **音频/视频转录**：新增 `.mp3 .wav .m4a .ogg` 格式支持；视频通过 ffmpeg 提取音轨后转录，转录文本分块嵌入索引
- **图片 OCR**：图片上传时同时生成语义描述 + OCR 文字，分别分块嵌入文本/omni 索引
- **VLM 系统提示**：更新 `KbVlmPromptAgent` 提示词，明确告知模型具备视觉能力
- **对话创建兜底**：Supabase 不可用时回退本地 UUID，避免前端流程中断

## Files Changed

- `fastapi_app/config/settings.py` — 新增 `KB_VLM_MODEL`、`VISUAL_EMBEDDING_*` 配置项
- `fastapi_app/services/visual_embedding_service.py` — 新文件，视觉 Embedding 服务
- `fastapi_app/routers/kb.py` — PDF 图片 API、图片附件描述、VLM 模型自动切换、对话 UUID 兜底
- `fastapi_app/routers/kb_sources.py` — 图片即时 OCR、媒体即时转录 fallback
- `fastapi_app/services/source_service.py` — 读取 OCR/转录文本路径
- `workflow_engine/state.py` — 新增 `retrieval_mode`、`query_image_data_urls` 字段
- `workflow_engine/workflow/wf_intelligent_qa.py` — omni/visual 检索融合逻辑
- `workflow_engine/promptstemplates/resources/pt_qa_agent_repo.py` — VLM 提示词重写
- `workflow_engine/toolkits/ragtool/vector_store_tool.py` — visual/omni 索引、音频转录、PDF 图片嵌入
- `requirements-base.txt` — 新增依赖

## Test plan

- [ ] 配置 `VISUAL_EMBEDDING_API_URL` 后上传 PDF，确认 visual/omni 索引生成
- [ ] VLM 模式下发送问题，确认优先走 omni 检索
- [ ] 上传音频文件，确认转录文本可被检索
- [ ] 上传图片，确认 OCR 文本可被检索
- [ ] 调用 `/kb/reindex-pdf-images` 接口，确认幂等性
- [ ] Supabase 未配置时，确认对话创建返回本地 UUID

🤖 Generated with [Claude Code](https://claude.com/claude-code)