### PR TITLE
feat: chat image attachments, VLM mode toggle, and PDF image gallery UI

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -903,6 +903,24 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmmirror.com/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/netbsd-x64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
@@ -920,6 +938,24 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmmirror.com/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/openbsd-x64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
@@ -935,6 +971,24 @@
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmmirror.com/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/sunos-x64": {
@@ -10718,6 +10772,420 @@
         }
       }
     },
+    "node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmmirror.com/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmmirror.com/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmmirror.com/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmmirror.com/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmmirror.com/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmmirror.com/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmmirror.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmmirror.com/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmmirror.com/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmmirror.com/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmmirror.com/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmmirror.com/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmmirror.com/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmmirror.com/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmmirror.com/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmmirror.com/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmmirror.com/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmmirror.com/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmmirror.com/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmmirror.com/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmmirror.com/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmmirror.com/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmmirror.com/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/vitest/node_modules/@vitest/mocker": {
       "version": "4.1.5",
       "resolved": "https://registry.npmmirror.com/@vitest/mocker/-/mocker-4.1.5.tgz",
@@ -10743,6 +11211,50 @@
         "vite": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vitest/node_modules/esbuild": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmmirror.com/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
       }
     },
     "node_modules/vitest/node_modules/picomatch": {

--- a/frontend/src/components/ThinkFlowCenterPanel.tsx
+++ b/frontend/src/components/ThinkFlowCenterPanel.tsx
@@ -1,4 +1,5 @@
 import type { MutableRefObject, ReactNode, RefObject } from 'react';
+import { useRef, useCallback } from 'react';
 import { Check, FileText, MessageSquarePlus, Plus } from 'lucide-react';
 
 import type {
@@ -8,6 +9,8 @@ import type {
   OutlineSection,
   WorkspaceMode,
   ChatMode,
+  RetrievalMode,
+  ChatAttachment,
 } from './thinkflow-types';
 import type { KnowledgeFile } from '../types';
 import { TableAnalysisPanel, type NotebookContext } from './TableAnalysisPanel';
@@ -52,6 +55,10 @@ type ThinkFlowCenterPanelProps = {
   dataSessionId: string | null;
   notebookContext: NotebookContext;
   chatDisabled?: boolean;
+  retrievalMode: RetrievalMode;
+  onRetrievalModeChange: (mode: RetrievalMode) => void;
+  chatAttachments: ChatAttachment[];
+  onAttachmentsChange: (attachments: ChatAttachment[]) => void;
 };
 
 export function ThinkFlowCenterPanel({
@@ -92,7 +99,49 @@ export function ThinkFlowCenterPanel({
   activeDataset,
   dataSessionId,
   notebookContext,
+  retrievalMode,
+  onRetrievalModeChange,
+  chatAttachments,
+  onAttachmentsChange,
 }: ThinkFlowCenterPanelProps) {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handleFileSelect = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = Array.from(e.target.files || []);
+    files.forEach((file) => {
+      const reader = new FileReader();
+      reader.onload = (ev) => {
+        const dataUrl = ev.target?.result as string;
+        onAttachmentsChange([
+          ...chatAttachments,
+          { id: `${Date.now()}_${Math.random()}`, dataUrl, fileName: file.name },
+        ]);
+      };
+      reader.readAsDataURL(file);
+    });
+    e.target.value = '';
+  }, [chatAttachments, onAttachmentsChange]);
+
+  const handlePaste = useCallback((e: React.ClipboardEvent<HTMLTextAreaElement>) => {
+    const items = Array.from(e.clipboardData.items);
+    const imageItems = items.filter((item) => item.type.startsWith('image/'));
+    if (imageItems.length === 0) return;
+    e.preventDefault();
+    imageItems.forEach((item) => {
+      const file = item.getAsFile();
+      if (!file) return;
+      const reader = new FileReader();
+      reader.onload = (ev) => {
+        const dataUrl = ev.target?.result as string;
+        onAttachmentsChange([
+          ...chatAttachments,
+          { id: `${Date.now()}_${Math.random()}`, dataUrl, fileName: 'pasted-image.png' },
+        ]);
+      };
+      reader.readAsDataURL(file);
+    });
+  }, [chatAttachments, onAttachmentsChange]);
+
   const formatReferenceDocumentLabel = (doc: ThinkFlowDocument) => {
     const focusState = doc.focus_state;
     if (focusState?.type === 'sections' && Array.isArray(focusState.section_ids) && focusState.section_ids.length > 0) {
@@ -255,6 +304,19 @@ export function ThinkFlowCenterPanel({
                     <span>{message.role === 'assistant' ? 'AI' : '你'}</span>
                     <span>{message.time}</span>
                   </div>
+                  {message.attachments && message.attachments.length > 0 && (
+                    <div className="thinkflow-bubble-attachments">
+                      {message.attachments.map((att) => (
+                        <img
+                          key={att.id}
+                          src={att.dataUrl}
+                          alt={att.fileName}
+                          className="thinkflow-bubble-attachment-img"
+                          title={att.fileName}
+                        />
+                      ))}
+                    </div>
+                  )}
                   {renderMessageMarkdown(message)}
                 </div>
                 {!isOutlineChatMode && (message.role === 'assistant' || message.role === 'user') ? (
@@ -316,7 +378,7 @@ export function ThinkFlowCenterPanel({
             className="thinkflow-multi-select-input"
             value={multiSelectPrompt}
             onChange={(event) => setMultiSelectPrompt(event.target.value)}
-            placeholder="可选：补充你希望这组内容如何被整理，例如‘沉淀成产出指导，强调结论和边界条件’"
+            placeholder="可选：补充你希望这组内容如何被整理，例如'沉淀成产出指导，强调结论和边界条件'"
             rows={2}
           />
         </div>
@@ -326,6 +388,23 @@ export function ThinkFlowCenterPanel({
       {chatMode !== 'table-analysis' && (
       <div className="thinkflow-chat-input-area">
         <div className="thinkflow-chat-input-box">
+          {/* 附件缩略图区 */}
+          {chatAttachments.length > 0 && (
+            <div className="thinkflow-attach-strip">
+              {chatAttachments.map((att) => (
+                <div key={att.id} className="thinkflow-attach-thumb">
+                  <img src={att.dataUrl} alt={att.fileName} />
+                  <button
+                    type="button"
+                    className="thinkflow-attach-thumb-remove"
+                    onClick={() => onAttachmentsChange(chatAttachments.filter((a) => a.id !== att.id))}
+                  >
+                    ×
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
           <textarea
             value={chatInput}
             onChange={(event) => setChatInput(event.target.value)}
@@ -335,13 +414,26 @@ export function ThinkFlowCenterPanel({
                 void handleSendMessage();
               }
             }}
-            placeholder={chatPlaceholder || '输入消息，围绕当前素材梳理你真正想要的结论...'}
+            onPaste={handlePaste}
+            placeholder={
+              retrievalMode === 'vlm'
+                ? '👁 VLM 模式：输入文字，或粘贴 / 附加图片进行多模态检索...'
+                : (chatPlaceholder || '输入消息，围绕当前素材梳理你真正想要的结论...')
+            }
             className="thinkflow-chat-input"
             rows={2}
           />
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/*"
+            multiple
+            style={{ display: 'none' }}
+            onChange={handleFileSelect}
+          />
           <div className="thinkflow-chat-toolbar">
             {isOutlineChatMode ? (
-              <span className="thinkflow-doc-check-tip">当前消息会综合来源、梳理文档、产出指导和当前产出文档，先整理这份 PPT 的候选修改；只有点击“应用候选修改”后才会覆盖正式产出文档，也不会写入普通问答历史。</span>
+              <span className="thinkflow-doc-check-tip">当前消息会综合来源、梳理文档、产出指导和当前产出文档，先整理这份 PPT 的候选修改；只有点击"应用候选修改"后才会覆盖正式产出文档，也不会写入普通问答历史。</span>
             ) : (
               <>
                 <button type="button" className="thinkflow-toolbar-btn">
@@ -372,10 +464,29 @@ export function ThinkFlowCenterPanel({
                     + 新建梳理
                   </button>
                 ) : null}
+                <div className="thinkflow-toolbar-divider" />
+                <button
+                  type="button"
+                  className={`thinkflow-retrieval-mode-btn${retrievalMode === 'vlm' ? ' is-active' : ''}`}
+                  onClick={() => onRetrievalModeChange(retrievalMode === 'vlm' ? 'text' : 'vlm')}
+                  title={retrievalMode === 'vlm' ? '当前：VLM 多模态检索，点击切换为文本检索' : '当前：文本检索，点击切换为 VLM 多模态检索'}
+                >
+                  {retrievalMode === 'vlm' ? '👁 VLM' : '📝 文本'}
+                </button>
+                {retrievalMode === 'vlm' && (
+                  <button
+                    type="button"
+                    className="thinkflow-toolbar-btn"
+                    onClick={() => fileInputRef.current?.click()}
+                    title="附加图片"
+                  >
+                    📎
+                  </button>
+                )}
               </>
             )}
             <div className="thinkflow-toolbar-spacer" />
-            <button type="button" className="thinkflow-send-btn" onClick={() => void handleSendMessage()} disabled={!chatInput.trim() || chatLoading}>
+            <button type="button" className="thinkflow-send-btn" onClick={() => void handleSendMessage()} disabled={(!chatInput.trim() && chatAttachments.length === 0) || chatLoading}>
               {chatLoading ? '...' : '↑'}
             </button>
           </div>

--- a/frontend/src/components/ThinkFlowLeftSidebar.tsx
+++ b/frontend/src/components/ThinkFlowLeftSidebar.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Eye, FolderOpen, Loader2, MessageCircle, MessageSquarePlus, Package, Plus, RefreshCw, Trash2, Upload } from 'lucide-react';
+import { Eye, FolderOpen, ImageIcon, Loader2, MessageCircle, MessageSquarePlus, Package, Plus, RefreshCw, Trash2, Upload } from 'lucide-react';
 
 import type { KnowledgeFile } from '../types';
 import { formatThinkFlowDateTime } from './thinkflow-document-utils';
@@ -36,6 +36,8 @@ type Props = {
   onRefreshFiles: () => void | Promise<void>;
   onToggleSource: (fileId: string) => void;
   onReEmbedSource: (file: KnowledgeFile) => Promise<void> | void;
+  onReindexPdfImages?: () => Promise<void> | void;
+  onExtractPdfImages?: (file: KnowledgeFile) => Promise<void> | void;
   outputs: SidebarOutput[];
   selectedIds: Set<string>;
   uploading: boolean;
@@ -88,6 +90,8 @@ export function ThinkFlowLeftSidebar({
   onRefreshFiles,
   onToggleSource,
   onReEmbedSource,
+  onReindexPdfImages,
+  onExtractPdfImages,
   outputs,
   selectedIds,
   uploading,
@@ -100,8 +104,19 @@ export function ThinkFlowLeftSidebar({
 }: Props) {
   const pendingCount = files.filter((file) => file.vectorStatus === 'pending').length;
   const selectedCount = selectedIds.size;
-  // 正在重新入库的文件 ID 集合（本地 loading 状态）
   const [embeddingIds, setEmbeddingIds] = useState<Set<string>>(new Set());
+  const [reindexing, setReindexing] = useState(false);
+  const [extractingIds, setExtractingIds] = useState<Set<string>>(new Set());
+
+  const handleReindexPdfImages = async () => {
+    if (reindexing || !onReindexPdfImages) return;
+    setReindexing(true);
+    try {
+      await onReindexPdfImages();
+    } finally {
+      setReindexing(false);
+    }
+  };
 
   const handleReEmbed = async (file: KnowledgeFile) => {
     if (embeddingIds.has(file.id)) return;
@@ -110,6 +125,20 @@ export function ThinkFlowLeftSidebar({
       await onReEmbedSource(file);
     } finally {
       setEmbeddingIds((prev) => {
+        const next = new Set(prev);
+        next.delete(file.id);
+        return next;
+      });
+    }
+  };
+
+  const handleExtractImages = async (file: KnowledgeFile) => {
+    if (extractingIds.has(file.id) || !onExtractPdfImages) return;
+    setExtractingIds((prev) => new Set([...prev, file.id]));
+    try {
+      await onExtractPdfImages(file);
+    } finally {
+      setExtractingIds((prev) => {
         const next = new Set(prev);
         next.delete(file.id);
         return next;
@@ -195,6 +224,17 @@ export function ThinkFlowLeftSidebar({
             >
               <RefreshCw size={14} className={loadingFiles ? 'is-spinning' : ''} />
             </button>
+            {onReindexPdfImages && (
+              <button
+                type="button"
+                className="thinkflow-left-refresh-btn"
+                onClick={() => void handleReindexPdfImages()}
+                disabled={reindexing}
+                title={reindexing ? '图片索引重建中…' : '重建 PDF 图片索引（VLM 模式）'}
+              >
+                {reindexing ? <Loader2 size={14} className="is-spinning" /> : <ImageIcon size={14} />}
+              </button>
+            )}
           </div>
 
           <div className="thinkflow-left-scroll">
@@ -250,6 +290,20 @@ export function ThinkFlowLeftSidebar({
                         {isReEmbedding
                           ? <Loader2 size={12} className="is-spinning" />
                           : <Upload size={12} />}
+                      </button>
+                    )}
+                    {/* 提取PDF图片按钮：仅对已入库的 doc 类型文件显示 */}
+                    {onExtractPdfImages && isEmbedded && file.type === 'doc' && (
+                      <button
+                        type="button"
+                        className="thinkflow-file-action-icon"
+                        onClick={(e) => { e.stopPropagation(); void handleExtractImages(file); }}
+                        disabled={extractingIds.has(file.id)}
+                        title={extractingIds.has(file.id) ? '提取中…' : '查看PDF图片'}
+                      >
+                        {extractingIds.has(file.id)
+                          ? <Loader2 size={12} className="is-spinning" />
+                          : <ImageIcon size={12} />}
                       </button>
                     )}
                     <button

--- a/frontend/src/components/ThinkFlowWorkspace.css
+++ b/frontend/src/components/ThinkFlowWorkspace.css
@@ -824,6 +824,26 @@
   color: rgba(255, 255, 255, 0.72);
 }
 
+.thinkflow-bubble-attachments {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 8px;
+}
+
+.thinkflow-bubble-attachment-img {
+  max-width: 220px;
+  max-height: 160px;
+  border-radius: 8px;
+  object-fit: cover;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  cursor: pointer;
+}
+
+.thinkflow-bubble-attachment-img:hover {
+  opacity: 0.9;
+}
+
 .thinkflow-message-markdown {
   font-size: 14px;
   line-height: 1.75;
@@ -1353,6 +1373,80 @@
 .thinkflow-doc-action-btn:disabled {
   opacity: 0.58;
   cursor: not-allowed;
+}
+
+/* ── Attachment strip ─────────────────────────────────────────────────────── */
+.thinkflow-attach-strip {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px 0;
+  overflow-x: auto;
+  flex-wrap: nowrap;
+}
+
+.thinkflow-attach-thumb {
+  position: relative;
+  flex-shrink: 0;
+  width: 56px;
+  height: 56px;
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid var(--tf-border);
+  background: var(--tf-bg-secondary);
+}
+
+.thinkflow-attach-thumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.thinkflow-attach-thumb-remove {
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  border: none;
+  background: rgba(0, 0, 0, 0.55);
+  color: #fff;
+  font-size: 11px;
+  line-height: 18px;
+  text-align: center;
+  cursor: pointer;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.thinkflow-attach-thumb-remove:hover {
+  background: rgba(220, 50, 50, 0.85);
+}
+
+/* ── Retrieval mode toggle ────────────────────────────────────────────────── */
+.thinkflow-retrieval-mode-btn {
+  font-size: 12px;
+  padding: 4px 8px;
+  border-radius: 6px;
+  border: 1px solid var(--tf-border);
+  background: rgba(255, 255, 255, 0.88);
+  color: var(--tf-subtle);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  white-space: nowrap;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+}
+
+.thinkflow-retrieval-mode-btn.is-active {
+  background: #ede9fe;
+  color: #6d28d9;
+  border-color: #c4b5fd;
 }
 
 .thinkflow-right-panel {
@@ -3038,6 +3132,34 @@
   gap: 4px;
   margin-bottom: 10px;
   color: #4d3721;
+}
+
+.thinkflow-retrieved-images {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 12px;
+  max-height: 520px;
+  overflow-y: auto;
+  padding-right: 4px;
+}
+
+.thinkflow-retrieved-image {
+  max-width: 100%;
+  max-height: 280px;
+  width: auto;
+  height: auto;
+  border-radius: 8px;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  object-fit: contain;
+  background: #f8f8f8;
+  cursor: zoom-in;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.thinkflow-retrieved-image:hover {
+  transform: scale(1.02);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
 }
 
 .thinkflow-inline-outline-card {

--- a/frontend/src/components/ThinkFlowWorkspace.tsx
+++ b/frontend/src/components/ThinkFlowWorkspace.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { flushSync } from 'react-dom';
 import ReactMarkdown from 'react-markdown';
 import remarkMath from 'remark-math';
 import rehypeKatex from 'rehype-katex';
@@ -59,7 +60,7 @@ import {
   type StructuredPushTransform,
   type ThinkFlowFocusState,
 } from './thinkflow-document-utils';
-import type { ChatMode } from './thinkflow-types';
+import type { ChatMode, RetrievalMode, ChatAttachment } from './thinkflow-types';
 import { splitSummaryCards } from './summaryCards';
 import type { NotebookContext } from './TableAnalysisPanel';
 import { usePptPageReviewManager } from './usePptPageReviewManager';
@@ -104,6 +105,8 @@ type ThinkFlowMessage = {
   sourcePreviewMapping?: Record<string, string>;
   sourceReferenceMapping?: Record<string, CitationReference>;
   meta?: Record<string, any>;
+  attachments?: ChatAttachment[];
+  retrievedImages?: string[];
 };
 
 type OutlineDirective = {
@@ -258,6 +261,7 @@ type ConversationMessageDraft = {
   sourceMapping?: Record<string, string>;
   sourcePreviewMapping?: Record<string, string>;
   sourceReferenceMapping?: Record<string, CitationReference>;
+  retrievedImages?: string[];
 };
 
 type OutlineChatSession = {
@@ -855,6 +859,8 @@ const ThinkFlowWorkspace = ({ notebook, onBack }: { notebook: Notebook; onBack: 
 
   // ─── 表格分析模式状态 ──────────────────────────────────────────────────────
   const [chatMode, setChatMode] = useState<ChatMode>('chat');
+  const [retrievalMode, setRetrievalMode] = useState<RetrievalMode>('text');
+  const [chatAttachments, setChatAttachments] = useState<ChatAttachment[]>([]);
   const [activeDataset, setActiveDataset] = useState<KnowledgeFile | null>(null);
   const [dataSessionId, setDataSessionId] = useState<string | null>(null);
   // ref 防重注册：fileId → datasource_id (int)，不触发重渲染
@@ -1748,6 +1754,7 @@ const ThinkFlowWorkspace = ({ notebook, onBack }: { notebook: Notebook; onBack: 
             sourceMapping: item.sourceMapping,
             sourcePreviewMapping: item.sourcePreviewMapping,
             sourceReferenceMapping: item.sourceReferenceMapping,
+            retrievedImages: (item as any).retrievedImages,
           }))
         : welcomeMessages,
     );
@@ -1809,10 +1816,30 @@ const ThinkFlowWorkspace = ({ notebook, onBack }: { notebook: Notebook; onBack: 
     return nextId;
   };
 
+  // Creates a conversation ID silently without resetting the chat UI.
+  // Used internally when a conversation must exist before sending the first message.
+  const createConversationSilent = async (): Promise<string> => {
+    const response = await apiFetch('/api/v1/kb/conversations', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        email: effectiveUser?.email || effectiveUser?.id || 'local',
+        user_id: effectiveUser?.id || 'local',
+        notebook_id: notebook.id,
+      }),
+    });
+    const data = await parseJson<{ conversation_id?: string; conversation?: ConversationListItem }>(response);
+    const nextId = String(data?.conversation_id || '').trim();
+    if (!nextId) throw new Error('创建新对话失败');
+    setConversationId(nextId);
+    void refreshConversationList().catch(() => {});
+    return nextId;
+  };
+
   const ensureConversationId = async () => {
     if (conversationId) return conversationId;
     try {
-      return await createConversation();
+      return await createConversationSilent();
     } catch {}
     return '';
   };
@@ -1826,6 +1853,7 @@ const ThinkFlowWorkspace = ({ notebook, onBack }: { notebook: Notebook; onBack: 
         sourceMapping: item.sourceMapping,
         sourcePreviewMapping: item.sourcePreviewMapping,
         sourceReferenceMapping: item.sourceReferenceMapping,
+        retrievedImages: item.retrievedImages,
       }))
       .filter((item) => item.content);
     if (rows.length === 0) return;
@@ -1915,6 +1943,62 @@ const ThinkFlowWorkspace = ({ notebook, onBack }: { notebook: Notebook; onBack: 
       await refreshFiles();
     } catch {
       pushToast('入库失败，请稍后重试', 'error', 4000);
+    }
+  };
+
+  const handleReindexPdfImages = async () => {
+    try {
+      await apiFetch('/api/v1/kb/reindex-pdf-images', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          notebook_id: notebook.id,
+          user_id: effectiveUser?.id || 'local',
+          email: effectiveUser?.email || effectiveUser?.id || 'local',
+        }),
+      });
+      pushToast('PDF 图片索引已重建，VLM 模式可以检索图片了', 'success', 4000);
+    } catch {
+      pushToast('图片索引重建失败，请稍后重试', 'error', 4000);
+    }
+  };
+
+  const handleExtractPdfImages = async (file: KnowledgeFile) => {
+    const fileId = file.kbFileId || file.id;
+    try {
+      const params = new URLSearchParams({
+        notebook_id: notebook.id,
+        email: effectiveUser?.email || effectiveUser?.id || 'local',
+        file_id: fileId,
+      });
+      const response = await apiFetch(`/api/v1/kb/pdf-images?${params.toString()}`);
+      const data = await parseJson<{ figures: Array<{ url: string; content: string }>; pages: Array<{ url: string; page_num: number }> }>(response);
+      const figures = data.figures || [];
+      const pages = data.pages || [];
+      const allImages = [
+        ...figures.map((f) => f.url),
+        ...pages.map((p) => p.url),
+      ];
+      if (allImages.length === 0) {
+        pushToast('该 PDF 暂无提取到的图片，请先点击"重建图片索引"', 'warning', 4000);
+        return;
+      }
+      const figureCount = figures.length;
+      const pageCount = pages.length;
+      const summary = [
+        figureCount > 0 ? `${figureCount} 张插图` : '',
+        pageCount > 0 ? `${pageCount} 张页面截图` : '',
+      ].filter(Boolean).join('、');
+      const galleryMessage: ThinkFlowMessage = {
+        id: `gallery-${Date.now()}`,
+        role: 'assistant',
+        content: `📄 **${file.name}** 的图片提取结果（${summary}）：`,
+        time: new Date().toISOString(),
+        retrievedImages: allImages,
+      };
+      setChatMessages((prev) => [...prev, galleryMessage]);
+    } catch {
+      pushToast('获取 PDF 图片失败，请稍后重试', 'error', 4000);
     }
   };
 
@@ -2154,6 +2238,19 @@ const ThinkFlowWorkspace = ({ notebook, onBack }: { notebook: Notebook; onBack: 
       >
         {message.content}
       </ReactMarkdown>
+      {message.retrievedImages && message.retrievedImages.length > 0 && (
+        <div className="thinkflow-retrieved-images">
+          {message.retrievedImages.map((url, index) => (
+            <img
+              key={index}
+              src={url}
+              alt={`检索图片 ${index + 1}`}
+              className="thinkflow-retrieved-image"
+              loading="lazy"
+            />
+          ))}
+        </div>
+      )}
       {message.meta?.type === 'ppt_outline_draft' ? (
         <div className="thinkflow-inline-outline-card" data-testid="ppt-outline-inline-card">
           <div className="thinkflow-inline-outline-card-head">
@@ -3284,6 +3381,7 @@ const ThinkFlowWorkspace = ({ notebook, onBack }: { notebook: Notebook; onBack: 
       role: 'user',
       content: query,
       time: formatThinkFlowTime(new Date()),
+      attachments: chatAttachments.length > 0 ? [...chatAttachments] : undefined,
     };
     const assistantMessage: ThinkFlowMessage = {
       id: `assistant_${Date.now()}`,
@@ -3294,6 +3392,7 @@ const ThinkFlowWorkspace = ({ notebook, onBack }: { notebook: Notebook; onBack: 
 
     setChatMessages((previous) => [...previous, userMessage, assistantMessage]);
     setChatInput('');
+    setChatAttachments([]);
 
     try {
       const targetConversationId = await ensureConversationId();
@@ -3331,6 +3430,8 @@ const ThinkFlowWorkspace = ({ notebook, onBack }: { notebook: Notebook; onBack: 
           email: effectiveUser?.email || '',
           user_id: effectiveUser?.id || 'local',
           notebook_id: notebook.id,
+          retrieval_mode: retrievalMode,
+          image_attachments: chatAttachments.map((a) => a.dataUrl),
         }),
       });
 
@@ -3344,6 +3445,7 @@ const ThinkFlowWorkspace = ({ notebook, onBack }: { notebook: Notebook; onBack: 
       let sourceMapping: ThinkFlowMessage['sourceMapping'];
       let sourcePreviewMapping: ThinkFlowMessage['sourcePreviewMapping'];
       let sourceReferenceMapping: ThinkFlowMessage['sourceReferenceMapping'];
+      let retrievedImages: ThinkFlowMessage['retrievedImages'];
 
       const syncAssistantMessage = (nextContent = fullAnswer) => {
         setChatMessages((previous) =>
@@ -3356,6 +3458,7 @@ const ThinkFlowWorkspace = ({ notebook, onBack }: { notebook: Notebook; onBack: 
                   sourceMapping,
                   sourcePreviewMapping,
                   sourceReferenceMapping,
+                  retrievedImages,
                 }
               : item,
           ),
@@ -3378,9 +3481,12 @@ const ThinkFlowWorkspace = ({ notebook, onBack }: { notebook: Notebook; onBack: 
             sourcePreviewMapping = payload.source_preview_mapping || undefined;
             sourceReferenceMapping = payload.source_reference_mapping || undefined;
             syncAssistantMessage();
+          } else if (payload.type === 'images') {
+            retrievedImages = payload.images || undefined;
+            syncAssistantMessage();
           } else if (payload.type === 'delta') {
             fullAnswer += payload.delta || '';
-            syncAssistantMessage();
+            flushSync(() => syncAssistantMessage());
           } else if (payload.type === 'done') {
             fullAnswer = payload.answer || fullAnswer;
             syncAssistantMessage();
@@ -3398,6 +3504,9 @@ const ThinkFlowWorkspace = ({ notebook, onBack }: { notebook: Notebook; onBack: 
           sourceMapping = payload.source_mapping || undefined;
           sourcePreviewMapping = payload.source_preview_mapping || undefined;
           sourceReferenceMapping = payload.source_reference_mapping || undefined;
+          syncAssistantMessage();
+        } else if (payload.type === 'images') {
+          retrievedImages = payload.images || undefined;
           syncAssistantMessage();
         } else if (payload.type === 'delta') {
           fullAnswer += payload.delta || '';
@@ -3418,6 +3527,7 @@ const ThinkFlowWorkspace = ({ notebook, onBack }: { notebook: Notebook; onBack: 
           sourceMapping,
           sourcePreviewMapping,
           sourceReferenceMapping,
+          retrievedImages,
         },
       ]);
       if (targetConversationId) {
@@ -4593,6 +4703,8 @@ const ThinkFlowWorkspace = ({ notebook, onBack }: { notebook: Notebook; onBack: 
           onUpload={handleUpload}
           onAddSource={() => setShowAddSourceModal(true)}
           onReEmbedSource={handleReEmbedSource}
+          onReindexPdfImages={handleReindexPdfImages}
+          onExtractPdfImages={handleExtractPdfImages}
           conversationList={conversationList}
           activeConversationId={conversationId}
           onSelectConversation={(id) => void loadConversationMessages(id)}
@@ -4652,6 +4764,10 @@ const ThinkFlowWorkspace = ({ notebook, onBack }: { notebook: Notebook; onBack: 
             userEmail: effectiveUser?.email || '',
           }}
           onSetActivePptSlideIndex={setActivePptSlideIndex}
+          retrievalMode={retrievalMode}
+          onRetrievalModeChange={setRetrievalMode}
+          chatAttachments={chatAttachments}
+          onAttachmentsChange={setChatAttachments}
         />
 
         {rightPanelOpen ? (

--- a/frontend/src/components/__tests__/ThinkFlowCenterPanel.test.tsx
+++ b/frontend/src/components/__tests__/ThinkFlowCenterPanel.test.tsx
@@ -70,6 +70,10 @@ function renderPptWorkbenchCenterPanel() {
       activeDataset={null}
       dataSessionId={null}
       notebookContext={{ notebookId: 'nb_1', notebookTitle: 'test427', userId: 'user_1', userEmail: 'u@example.com' }}
+      retrievalMode="text"
+      onRetrievalModeChange={noop}
+      chatAttachments={[]}
+      onAttachmentsChange={noop}
     />,
   );
   return { setActivePptSlideIndex };

--- a/frontend/src/components/thinkflow-types.ts
+++ b/frontend/src/components/thinkflow-types.ts
@@ -15,6 +15,13 @@ export type CitationReference = {
 
 export type PushDestinationType = 'summary' | 'document' | 'guidance';
 
+export type RetrievalMode = 'text' | 'vlm';
+export type ChatAttachment = {
+  id: string;
+  dataUrl: string;
+  fileName: string;
+};
+
 export type ThinkFlowMessage = {
   id: string;
   role: 'user' | 'assistant' | 'system';
@@ -27,6 +34,7 @@ export type ThinkFlowMessage = {
   sourcePreviewMapping?: Record<string, string>;
   sourceReferenceMapping?: Record<string, CitationReference>;
   meta?: Record<string, any>;
+  attachments?: ChatAttachment[];
 };
 
 export type OutlineDirective = {


### PR DESCRIPTION
## Summary

- **聊天图片附件**：输入框上方新增缩略图条，支持通过文件选择器或 Ctrl+V 粘贴图片；图片显示在用户消息气泡中
- **VLM / 文本检索切换**：工具栏新增 📝/👁 切换按钮，VLM 模式时 placeholder 提示多模态操作
- **检索图片展示**：VLM 模式下后端返回的检索到的图片直接渲染在 AI 回复下方，使用 `flushSync` 保证流式实时渲染
- **PDF 图片画廊**：左侧边栏每个已入库文档增加「查看 PDF 图片」按钮，点击后在对话中展示提取到的插图和页面截图
- **重建图片索引按钮**：侧边栏顶部增加全局「重建 PDF 图片索引」按钮（触发 `/kb/reindex-pdf-images`）
- **发送逻辑优化**：有附件时即使文本为空也允许发送；消息发送后清空附件列表

## Files Changed

- `frontend/src/components/thinkflow-types.ts` — 新增 `RetrievalMode`、`ChatAttachment` 类型
- `frontend/src/components/ThinkFlowCenterPanel.tsx` — 附件 UI、粘贴处理、检索模式切换按钮
- `frontend/src/components/ThinkFlowWorkspace.tsx` — 附件状态、发送逻辑、PDF 图片画廊、检索图片渲染
- `frontend/src/components/ThinkFlowWorkspace.css` — 附件条、缩略图、检索模式按钮、检索图片样式
- `frontend/src/components/ThinkFlowLeftSidebar.tsx` — 重建索引按钮、单文件查看图片按钮
- `frontend/src/components/__tests__/ThinkFlowCenterPanel.test.tsx` — 补充新必填 props
- `frontend/package-lock.json` — 依赖锁文件更新

## Test plan

- [ ] 在 VLM 模式下，点击 📎 选择图片，确认缩略图显示并可删除
- [ ] 粘贴剪贴板图片，确认自动添加到附件
- [ ] 发送带图片消息，确认用户气泡中显示图片
- [ ] VLM 模式下发送问题，确认 AI 回复下方渲染检索图片
- [ ] 点击文件「查看 PDF 图片」按钮，确认图片画廊出现在对话中
- [ ] 点击「重建 PDF 图片索引」，确认 toast 提示成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)