### PR TITLE
fix: snapshot FileList before async upload, lazy-load PaddleOCR, update monitor script

### DIFF
--- a/frontend/src/components/ThinkFlowAddSourceModal.tsx
+++ b/frontend/src/components/ThinkFlowAddSourceModal.tsx
@@ -86,11 +86,15 @@ export function ThinkFlowAddSourceModal({
   // ── File Upload ──
   const uploadFiles = useCallback(
     async (fileList: FileList) => {
-      if (fileList.length === 0) return;
+      // Snapshot files immediately — FileList (and DataTransfer.files) is a live
+      // object that gets cleared as soon as the input is reset or the drag event
+      // ends, so we can't rely on fileList.length after the first await.
+      const files = Array.from(fileList);
+      if (files.length === 0) return;
       setLoading(true);
       resetMessages();
       try {
-        for (const file of Array.from(fileList)) {
+        for (const file of files) {
           const formData = new FormData();
           formData.append('file', file);
           formData.append('email', effectiveEmail);
@@ -100,7 +104,7 @@ export function ThinkFlowAddSourceModal({
           const res = await apiFetch('/api/v1/kb/upload', { method: 'POST', body: formData });
           await parseJson(res);
         }
-        setSuccess(`已上传 ${fileList.length} 个文件`);
+        setSuccess(`已上传 ${files.length} 个文件`);
         onSourceAdded();
       } catch (err: any) {
         setError(err?.message || '上传失败');
@@ -334,7 +338,7 @@ export function ThinkFlowAddSourceModal({
             >
               {loading ? <Loader2 size={22} className="is-spinning" /> : <Upload size={22} />}
               <span>{loading ? '上传中...' : '拖拽文件到此处，或点击选择文件'}</span>
-              <small>支持 PDF / Word / 图片 / CSV 等格式，可多选</small>
+              <small>支持 PDF / Word / 图片 / 音频 / 视频 / CSV 等格式，可多选</small>
               <input ref={fileInputRef} type="file" multiple hidden onChange={handleFileChange} disabled={loading} />
             </div>
           ) : null}

--- a/scripts/monitor.sh
+++ b/scripts/monitor.sh
@@ -50,7 +50,13 @@ fi
 
 log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1" >> logs/monitor.log; }
 
-is_port_up()   { ss -tlnH "sport = :$1" 2>/dev/null | grep -q LISTEN; }
+is_port_up()   {
+    if command -v ss >/dev/null 2>&1; then
+        ss -tlnH "sport = :$1" 2>/dev/null | grep -q LISTEN
+    else
+        lsof -iTCP:"$1" -sTCP:LISTEN -P -n >/dev/null 2>&1
+    fi
+}
 http_ok()       { curl --max-time 5 -fsS -o /dev/null "$1"; }
 proc_age()      { ps -o etimes= -p "$1" 2>/dev/null | awk '{print $1}'; }
 find_backend()  { pgrep -f "uvicorn fastapi_app.main:app.*--port ${BACKEND_PORT}" | head -1; }

--- a/workflow_engine/toolkits/multimodaltool/ppt_tool.py
+++ b/workflow_engine/toolkits/multimodaltool/ppt_tool.py
@@ -66,7 +66,7 @@ from pathlib import Path
 import numpy as np
 from PIL import Image
 import cv2
-from paddleocr import PaddleOCR
+# paddleocr is an optional heavy dependency; imported lazily in _get_paddle_ocr()
 
 from pptx import Presentation
 from pptx.util import Inches, Pt
@@ -117,13 +117,19 @@ SUBTITLE_RATIO_MAX = 2.0  # 副标题最大倍率
 BODY_RATIO_MIN = 0.9  # 正文最小倍率
 BODY_RATIO_MAX = 1.1  # 正文最大倍率
 
-# PaddleOCR 配置（全局只初始化一次）
-PADDLE_OCR = PaddleOCR(
-    use_angle_cls=True,  # 角度分类，处理横竖混排
-    lang="ch",  # 中文 + 英文
-    det_db_unclip_ratio=1.2 ,
-    det_db_box_thresh=0.5
-)
+_PADDLE_OCR = None
+
+def _get_paddle_ocr():
+    global _PADDLE_OCR
+    if _PADDLE_OCR is None:
+        from paddleocr import PaddleOCR
+        _PADDLE_OCR = PaddleOCR(
+            use_angle_cls=True,
+            lang="ch",
+            det_db_unclip_ratio=1.2,
+            det_db_box_thresh=0.5,
+        )
+    return _PADDLE_OCR
 
 # ----------------------------
 # Font Size Clustering
@@ -470,11 +476,11 @@ def paddle_ocr(bgr: np.ndarray, drop_score: int = DROP_SCORE):
 
     # PaddleOCR 2.x 支持 cls=True；3.x 已移除该参数，且返回结构改为 dict 列表。
     try:
-        ocr_result = PADDLE_OCR.ocr(bgr, cls=True)
+        ocr_result = _get_paddle_ocr().ocr(bgr, cls=True)
     except TypeError as e:
         if "unexpected keyword argument 'cls'" not in str(e):
             raise
-        ocr_result = PADDLE_OCR.ocr(bgr)
+        ocr_result = _get_paddle_ocr().ocr(bgr)
     lines = []
 
     if not ocr_result:


### PR DESCRIPTION
## Summary

- **FileList snapshot 修复**：`ThinkFlowAddSourceModal` 拖拽上传时，在第一个 `await` 前立即将 `FileList` 转为 `Array`，防止拖拽事件结束或 input reset 后 FileList 被清空导致文件丢失
- **PaddleOCR 懒加载**：将 `PaddleOCR` 的 import 和初始化延迟到首次调用时，避免未安装 paddleocr 时服务启动崩溃
- **monitor.sh 更新**：监控脚本小幅调整

## Files Changed

- `frontend/src/components/ThinkFlowAddSourceModal.tsx` — 上传前 snapshot FileList
- `workflow_engine/toolkits/multimodaltool/ppt_tool.py` — PaddleOCR 懒加载
- `scripts/monitor.sh` — 脚本更新

## Test plan

- [ ] 拖拽多个文件上传，确认成功提示数量与实际文件数一致
- [ ] 未安装 paddleocr 时启动服务，确认不报 ImportError

🤖 Generated with [Claude Code](https://claude.com/claude-code)